### PR TITLE
gputop-perf: remove stropts.h header

### DIFF
--- a/gputop/gputop-perf.c
+++ b/gputop/gputop-perf.c
@@ -35,7 +35,6 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
-#include <stropts.h>
 
 #include <limits.h>
 #include <errno.h>


### PR DESCRIPTION
This header doesn't seem to be needed, at least on fedora??