### PR TITLE
gputop-perf: fix memory leak

### DIFF
--- a/gputop/gputop-perf.c
+++ b/gputop/gputop-perf.c
@@ -1344,6 +1344,7 @@ gputop_i915_perf_oa_trace_close(void)
 
     gputop_perf_stream_unref(gputop_current_perf_stream);
 
+    free(gputop_perf_trace_buffer);
     gputop_current_perf_query = NULL;
     gputop_current_perf_stream = NULL;
 }


### PR DESCRIPTION
We need to free gputop_perf_trace_buffer in gputop_i915_oa_trace_close