### PR TITLE
web: Fix position of the overview bar graph

### DIFF
--- a/gputop/web/gputop-ui.js
+++ b/gputop/web/gputop-ui.js
@@ -638,7 +638,7 @@ function setup_overview_for_oa_query(idx)
 	//$.plot($(graph), [ graph_data ], { series: { lines: { show: true, fill: true }, shadowSize: 0 },
 //					   xaxis: { min: x_min, max: x_max },
 //					   yaxis: { max: 100 }
-    var axis = $("<div/>", { style: "height:2em; width:200px;"});
+    var axis = $("<div/>", { style: "height:2em; width:200px; position:relative"});
     var div = $("<div/>", { style: "display:flex; flex-direction:row;" } )
 		.append($("<div/>", { style: "width:20em; flex: 0 1 auto;" }))
 		    .append(axis);


### PR DESCRIPTION
The overview bar graph (with the 0-100 scale) appears to be
in different positions depending on the browser. Adding the
position:relative fixes this problem.