### PR TITLE
Consider context-switch on GEN8+

### DIFF
--- a/gputop/gputop-perf.h
+++ b/gputop/gputop-perf.h
@@ -54,6 +54,7 @@ typedef enum {
 
 struct gputop_devinfo {
     uint32_t devid;
+    uint32_t gen;
     uint64_t n_eus;
     uint64_t n_eu_slices;
     uint64_t n_eu_sub_slices;
@@ -217,6 +218,7 @@ struct gputop_perf_stream
 
     struct gputop_perf_query *query;
     bool overwrite;
+    bool per_ctx_mode;
 
     enum gputop_perf_stream_type type;
 


### PR DESCRIPTION
On GEN8+ the hardware generates a report to indicate when a context-switch
occurs. This should now be handled properly, as we now use this special
report as the base for subsequent accumulation calculations.