### PR TITLE
gputop-web-worker: Dynamically add items to the metric set drop-down.

### DIFF
--- a/gputop/gputop-perf.h
+++ b/gputop/gputop-perf.h
@@ -97,6 +97,7 @@ struct gputop_perf_query_counter
 struct gputop_perf_query
 {
     const char *name;
+    const char *symbol_name;
     const char *guid;
     struct gputop_perf_query_counter *counters;
     int n_counters;
@@ -281,8 +282,10 @@ extern struct gputop_perf_stream *gputop_current_perf_stream;
 
 bool gputop_enumerate_queries_via_sysfs(void);
 bool gputop_perf_initialize(void);
+void gputop_perf_free(void);
 
-bool gputop_i915_perf_oa_overview_open(int metric_set, bool enable_per_ctx);
+bool gputop_i915_perf_oa_overview_open(struct gputop_perf_query *query,
+                                       bool enable_per_ctx);
 void gputop_i915_perf_oa_overview_close(void);
 
 int fake_read(struct gputop_perf_stream *stream, uint8_t *buf, int buf_length);
@@ -297,11 +300,12 @@ void gputop_i915_perf_print_records(struct gputop_perf_stream *stream,
 				    uint8_t *buf,
 				    int len);
 
-bool gputop_i915_perf_oa_trace_open(int metric_set, bool enable_per_ctx);
+bool gputop_i915_perf_oa_trace_open(struct gputop_perf_query *query,
+                                    bool enable_per_ctx);
 void gputop_i915_perf_oa_trace_close(void);
 
-extern struct gputop_perf_query i915_perf_oa_queries[I915_OA_METRICS_SET_MAX];
 extern struct gputop_hash_table *queries;
+extern struct array *perf_oa_supported_query_guids;
 extern int gputop_perf_trace_buffer_size;
 extern uint8_t *gputop_perf_trace_buffer;
 extern bool gputop_perf_trace_empty;

--- a/gputop/gputop-server.c
+++ b/gputop/gputop-server.c
@@ -540,11 +540,12 @@ handle_open_i915_perf_oa_query(h2o_websocket_conn_t *conn,
     Gputop__OpenQuery *open_query = request->open_query;
     uint32_t id = open_query->id;
     Gputop__OAQueryInfo *oa_query_info = open_query->oa_query;
-    struct gputop_perf_query *perf_query;
+    struct gputop_perf_query *perf_query = NULL;
     struct gputop_perf_stream *stream;
     char *error = NULL;
     int buffer_size;
     Gputop__Message message = GPUTOP__MESSAGE__INIT;
+    int i;
 
     if (!gputop_perf_initialize()) {
 	message.reply_uuid = request->uuid;
@@ -555,7 +556,20 @@ handle_open_i915_perf_oa_query(h2o_websocket_conn_t *conn,
     }
     dbg("handle_open_i915_oa_query\n");
 
-    perf_query = &i915_perf_oa_queries[oa_query_info->metric_set];
+    for (i = 0; i < perf_oa_supported_query_guids->len; i++)
+    {
+        struct gputop_perf_query *query = (gputop_hash_table_search(queries,
+            array_value_at(perf_oa_supported_query_guids, char*, i)))->data;
+
+        if (query->perf_oa_metrics_set == oa_query_info->metric_set) {
+            perf_query = query;
+            break;
+        }
+    }
+
+    if (perf_query == NULL)
+        return;
+
     // TODO(matt-auld): Add support for per-ctx OA metrics for the web-ui
     perf_query->per_ctx_mode = false;
 
@@ -932,6 +946,7 @@ static void on_ws_message(h2o_websocket_conn_t *conn,
 
     if (arg == NULL) {
 	//dbg("socket closed\n");
+        gputop_perf_free();
 	close_all_streams();
         h2o_websocket_close(conn);
         return;

--- a/gputop/gputop-server.c
+++ b/gputop/gputop-server.c
@@ -875,6 +875,7 @@ handle_get_features(h2o_websocket_conn_t *conn,
     Gputop__Message message = GPUTOP__MESSAGE__INIT;
     Gputop__Features features = GPUTOP__FEATURES__INIT;
     Gputop__DevInfo devinfo = GPUTOP__DEV_INFO__INIT;
+    int i;
 
     if (!gputop_perf_initialize()) {
 	message.reply_uuid = request->uuid;
@@ -911,6 +912,15 @@ handle_get_features(h2o_websocket_conn_t *conn,
     read_file("/proc/sys/kernel/version", kernel_version, sizeof(kernel_version));
     features.kernel_release = kernel_release;
     features.kernel_build = kernel_version;
+    features.supported_oa_query_guids = xmalloc0(sizeof(char*) *
+        perf_oa_supported_query_guids->len);
+    features.n_supported_oa_query_guids = perf_oa_supported_query_guids->len;
+
+    for (i = 0; i < perf_oa_supported_query_guids->len; i++)
+    {
+        features.supported_oa_query_guids[i] =
+            (char*)array_value_at(perf_oa_supported_query_guids, char*, i);
+    }
 
     message.reply_uuid = request->uuid;
     message.cmd_case = GPUTOP__MESSAGE__CMD_FEATURES;
@@ -936,6 +946,8 @@ handle_get_features(h2o_websocket_conn_t *conn,
     dbg("  Kernel Build = %s\n", features.kernel_build);
 
     send_pb_message(conn, &message.base);
+
+    free(features.supported_oa_query_guids);
 }
 
 static void on_ws_message(h2o_websocket_conn_t *conn,

--- a/gputop/gputop-ui.c
+++ b/gputop/gputop-ui.c
@@ -65,12 +65,13 @@ struct tab
     char *nick;
     char *name;
 
-    void (*enter)(void);    /* when user switches to tab */
+    void (*enter)(struct tab*);    /* when user switches to tab */
     void (*leave)(void);    /* when user switches away from tab */
     void (*input)(int key);
     void (*redraw)(WINDOW *win);
 
     unsigned int gl_query_id;
+    struct gputop_perf_query *query;
 };
 
 #define TAB_TITLE_WIDTH 15
@@ -519,16 +520,16 @@ perf_oa_trace_redraw(WINDOW *win)
 }
 
 static void
-perf_3d_tab_enter(void)
+perf_tab_enter(struct tab *owner_tab)
 {
     uv_timer_init(gputop_ui_loop, &timer);
     uv_timer_start(&timer, timer_cb, 1000, 1000);
 
-    gputop_i915_perf_oa_overview_open(I915_OA_METRICS_SET_3D, false);
+    gputop_i915_perf_oa_overview_open(owner_tab->query, false);
 }
 
 static void
-perf_3d_tab_leave(void)
+perf_tab_leave(void)
 {
     gputop_i915_perf_oa_overview_close();
 
@@ -536,263 +537,19 @@ perf_3d_tab_leave(void)
 }
 
 static void
-perf_3d_tab_input(int key)
+perf_tab_input(int key)
 {
 
 }
 
 static void
-perf_3d_tab_redraw(WINDOW *win)
+perf_tab_redraw(WINDOW *win)
 {
     perf_counters_redraw(win);
 }
 
-static struct tab tab_3d =
-{
-    .nick = "3D",
-    .name = "3D Counters (system wide)",
-    .enter = perf_3d_tab_enter,
-    .leave = perf_3d_tab_leave,
-    .input = perf_3d_tab_input,
-    .redraw = perf_3d_tab_redraw,
-};
-
 static void
-perf_per_ctx_3d_tab_enter(void)
-{
-    uv_timer_init(gputop_ui_loop, &timer);
-    uv_timer_start(&timer, timer_cb, 1000, 1000);
-
-    gputop_i915_perf_oa_overview_open(I915_OA_METRICS_SET_3D, true);
-}
-
-static void
-perf_per_ctx_3d_tab_leave(void)
-{
-    gputop_i915_perf_oa_overview_close();
-
-    uv_timer_stop(&timer);
-}
-
-static void
-perf_per_ctx_3d_tab_input(int key)
-{
-
-}
-
-static void
-perf_per_ctx_3d_tab_redraw(WINDOW *win)
-{
-    perf_counters_redraw(win);
-}
-
-static struct tab tab_per_ctx_3d =
-{
-    .nick = "3D (per-context)",
-    .name = "3D Counters (per-context)",
-    .enter = perf_per_ctx_3d_tab_enter,
-    .leave = perf_per_ctx_3d_tab_leave,
-    .input = perf_per_ctx_3d_tab_input,
-    .redraw = perf_per_ctx_3d_tab_redraw,
-};
-
-static void
-perf_compute_tab_enter(void)
-{
-    uv_timer_init(gputop_ui_loop, &timer);
-    uv_timer_start(&timer, timer_cb, 1000, 1000);
-
-    gputop_i915_perf_oa_overview_open(I915_OA_METRICS_SET_COMPUTE, false);
-}
-
-static void
-perf_compute_tab_leave(void)
-{
-    gputop_i915_perf_oa_overview_close();
-
-    uv_timer_stop(&timer);
-}
-
-static void
-perf_compute_tab_input(int key)
-{
-
-}
-
-static void
-perf_compute_tab_redraw(WINDOW *win)
-{
-    perf_counters_redraw(win);
-}
-
-static struct tab tab_compute =
-{
-    .nick = "GPGPU",
-    .name = "Compute Counters (system wide)",
-    .enter = perf_compute_tab_enter,
-    .leave = perf_compute_tab_leave,
-    .input = perf_compute_tab_input,
-    .redraw = perf_compute_tab_redraw,
-};
-
-static void
-perf_compute_extended_tab_enter(void)
-{
-    uv_timer_init(gputop_ui_loop, &timer);
-    uv_timer_start(&timer, timer_cb, 1000, 1000);
-
-    gputop_i915_perf_oa_overview_open(I915_OA_METRICS_SET_COMPUTE_EXTENDED, false);
-}
-
-static void
-perf_compute_extended_tab_leave(void)
-{
-    gputop_i915_perf_oa_overview_close();
-
-    uv_timer_stop(&timer);
-}
-
-static void
-perf_compute_extended_tab_input(int key)
-{
-
-}
-
-static void
-perf_compute_extended_tab_redraw(WINDOW *win)
-{
-    perf_counters_redraw(win);
-}
-
-static struct tab tab_compute_extended =
-{
-    .nick = "GPGPU+",
-    .name = "Extended Compute Counters (system wide)",
-    .enter = perf_compute_extended_tab_enter,
-    .leave = perf_compute_extended_tab_leave,
-    .input = perf_compute_extended_tab_input,
-    .redraw = perf_compute_extended_tab_redraw,
-};
-
-static void
-perf_memory_reads_tab_enter(void)
-{
-    uv_timer_init(gputop_ui_loop, &timer);
-    uv_timer_start(&timer, timer_cb, 1000, 1000);
-
-    gputop_i915_perf_oa_overview_open(I915_OA_METRICS_SET_MEMORY_READS, false);
-}
-
-static void
-perf_memory_reads_tab_leave(void)
-{
-    gputop_i915_perf_oa_overview_close();
-
-    uv_timer_stop(&timer);
-}
-
-static void
-perf_memory_reads_tab_input(int key)
-{
-
-}
-
-static void
-perf_memory_reads_tab_redraw(WINDOW *win)
-{
-    perf_counters_redraw(win);
-}
-
-static struct tab tab_memory_reads =
-{
-    .nick = "MemR",
-    .name = "Memory Reads (system wide)",
-    .enter = perf_memory_reads_tab_enter,
-    .leave = perf_memory_reads_tab_leave,
-    .input = perf_memory_reads_tab_input,
-    .redraw = perf_memory_reads_tab_redraw,
-};
-
-static void
-perf_memory_writes_tab_enter(void)
-{
-    uv_timer_init(gputop_ui_loop, &timer);
-    uv_timer_start(&timer, timer_cb, 1000, 1000);
-
-    gputop_i915_perf_oa_overview_open(I915_OA_METRICS_SET_MEMORY_WRITES, false);
-}
-
-static void
-perf_memory_writes_tab_leave(void)
-{
-    gputop_i915_perf_oa_overview_close();
-
-    uv_timer_stop(&timer);
-}
-
-static void
-perf_memory_writes_tab_input(int key)
-{
-
-}
-
-static void
-perf_memory_writes_tab_redraw(WINDOW *win)
-{
-    perf_counters_redraw(win);
-}
-
-static struct tab tab_memory_writes =
-{
-    .nick = "MemW",
-    .name = "Memory Writes (system wide)",
-    .enter = perf_memory_writes_tab_enter,
-    .leave = perf_memory_writes_tab_leave,
-    .input = perf_memory_writes_tab_input,
-    .redraw = perf_memory_writes_tab_redraw,
-};
-
-static void
-perf_sampler_balance_tab_enter(void)
-{
-    uv_timer_init(gputop_ui_loop, &timer);
-    uv_timer_start(&timer, timer_cb, 1000, 1000);
-
-    gputop_i915_perf_oa_overview_open(I915_OA_METRICS_SET_SAMPLER_BALANCE, false);
-}
-
-static void
-perf_sampler_balance_tab_leave(void)
-{
-    gputop_i915_perf_oa_overview_close();
-
-    uv_timer_stop(&timer);
-}
-
-static void
-perf_sampler_balance_tab_input(int key)
-{
-
-}
-
-static void
-perf_sampler_balance_tab_redraw(WINDOW *win)
-{
-    perf_counters_redraw(win);
-}
-
-static struct tab tab_sampler_balance =
-{
-    .nick = "Sampler Balance",
-    .name = "Sampler Balance (system wide)",
-    .enter = perf_sampler_balance_tab_enter,
-    .leave = perf_sampler_balance_tab_leave,
-    .input = perf_sampler_balance_tab_input,
-    .redraw = perf_sampler_balance_tab_redraw,
-};
-
-static void
-perf_3d_trace_tab_enter(void)
+perf_3d_trace_tab_enter(struct tab *owner_tab)
 {
     y_pos = 0;
     zoom = 1;
@@ -800,7 +557,7 @@ perf_3d_trace_tab_enter(void)
     uv_timer_init(gputop_ui_loop, &timer);
     uv_timer_start(&timer, timer_cb, 100, 100);
 
-    gputop_i915_perf_oa_trace_open(I915_OA_METRICS_SET_3D, false);
+    gputop_i915_perf_oa_trace_open(owner_tab->query, false);
 }
 
 static void
@@ -1000,7 +757,7 @@ gl_perf_query_tab_redraw(WINDOW *win)
 }
 
 static void
-gl_perf_query_tab_enter(void)
+gl_perf_query_tab_enter(struct tab *owner_tab)
 {
     struct winsys_context **contexts;
     int i;
@@ -1082,7 +839,7 @@ gl_perf_query_tab_input(int key)
 }
 
 static void
-gl_debug_log_tab_enter(void)
+gl_debug_log_tab_enter(struct tab *owner_tab)
 {
 
 }
@@ -1156,7 +913,7 @@ static struct tab tab_gl_debug_log =
 };
 
 static void
-gl_knobs_tab_enter(void)
+gl_knobs_tab_enter(struct tab *owner_tab)
 {
 
 }
@@ -1193,7 +950,7 @@ static struct tab tab_gl_knobs =
 
 #if 0
 static void
-app_io_tab_enter(void)
+app_io_tab_enter(struct tab *owner_tab)
 {
 
 }
@@ -1285,7 +1042,7 @@ redraw_ui(void)
 	if (switch_to_tab) {
 	    current_tab->leave();
 	    current_tab = switch_to_tab;
-	    current_tab->enter();
+	    current_tab->enter(current_tab);
 	}
     }
 #endif
@@ -1403,7 +1160,7 @@ common_input(int key)
     if (next) {
 	current_tab->leave();
 	current_tab = next;
-	current_tab->enter();
+	current_tab->enter(current_tab);
 
 	return INPUT_HANDLED;
     }
@@ -1507,6 +1264,7 @@ init_ncurses(FILE *infile, FILE *outfile)
 void *
 gputop_ui_run(void *arg)
 {
+    struct tab *tab, *tmp;
 #ifdef SUPPORT_WEBUI
     const char *mode = getenv("GPUTOP_MODE");
 
@@ -1582,11 +1340,16 @@ gputop_ui_run(void *arg)
     {
 	uv_idle_init(gputop_ui_loop, &redraw_idle);
 
-	current_tab = &tab_3d;
-	current_tab->enter();
+	current_tab->enter(current_tab);
     }
 
     uv_run(gputop_ui_loop, UV_RUN_DEFAULT);
+
+    gputop_perf_free();
+
+    gputop_list_for_each_safe(tab, tmp, &tabs, link) {
+        free (tab);
+    }
 
     return 0;
 }
@@ -1594,18 +1357,43 @@ gputop_ui_run(void *arg)
 __attribute__((constructor)) void
 gputop_ui_init(void)
 {
+    int i;
     pthread_attr_t attrs;
+    struct gputop_perf_query *trace_query = NULL;
 
+    gputop_perf_initialize();
     gputop_list_init(&tabs);
+    current_tab = NULL;
 
-    gputop_list_insert(tabs.prev, &tab_3d.link);
-    gputop_list_insert(tabs.prev, &tab_per_ctx_3d.link);
-    gputop_list_insert(tabs.prev, &tab_compute.link);
-    gputop_list_insert(tabs.prev, &tab_compute_extended.link);
-    gputop_list_insert(tabs.prev, &tab_memory_reads.link);
-    gputop_list_insert(tabs.prev, &tab_memory_writes.link);
-    gputop_list_insert(tabs.prev, &tab_sampler_balance.link);
-    gputop_list_insert(tabs.prev, &tab_3d_trace.link);
+    for (i = 0; i < perf_oa_supported_query_guids->len; i++)
+    {
+        struct gputop_perf_query *query = (gputop_hash_table_search(queries,
+            array_value_at(perf_oa_supported_query_guids, char*, i)))->data;
+        struct tab *counter_tab = xmalloc0(sizeof(struct tab));
+
+        counter_tab->name = (char*)query->name;
+        counter_tab->nick = (char*)query->symbol_name;
+        counter_tab->query = query;
+        counter_tab->enter = perf_tab_enter;
+        counter_tab->leave = perf_tab_leave;
+        counter_tab->input = perf_tab_input;
+        counter_tab->redraw = perf_tab_redraw;
+        gputop_list_insert(tabs.prev, &counter_tab->link);
+
+        if (current_tab == NULL)
+            current_tab = counter_tab;
+        if (trace_query == NULL &&
+            strcmp(counter_tab->nick, "RenderBasic") == 0)
+        {
+            current_tab = counter_tab;
+            trace_query = query;
+        }
+    }
+
+    if (trace_query != NULL) {
+        tab_3d_trace.query = trace_query;
+        gputop_list_insert(tabs.prev, &tab_3d_trace.link);
+    }
 #ifdef SUPPORT_GL
     gputop_list_insert(tabs.prev, &tab_gl_debug_log.link);
 #endif

--- a/gputop/gputop.proto
+++ b/gputop/gputop.proto
@@ -64,6 +64,7 @@ message Features
     required string kernel_release = 7;
     required string kernel_build = 8;
     required bool fake_mode = 9;
+    repeated string supported_oa_query_guids = 10;
 }
 
 message LogEntry

--- a/gputop/oa-gen.py
+++ b/gputop/oa-gen.py
@@ -459,8 +459,9 @@ for set in tree.findall(".//set"):
     c("struct gputop_perf_query *query;\n")
     c("struct gputop_perf_query_counter *counter;\n\n")
 
-    c("query = &i915_perf_oa_queries[" + perf_id + "];\n")
+    c("query = xmalloc0(sizeof(struct gputop_perf_query));\n")
     c("query->name = \"" + set.get('name') + "\";\n")
+    c("query->symbol_name = \"" + set.get('symbol_name') + "\";\n")
     c("query->guid = \"" + set.get('guid') + "\";\n")
     c("gputop_hash_table_insert(queries, query->guid, query);\n")
     c("query->counters = xmalloc0(sizeof(struct gputop_perf_query_counter) * " + str(len(counters)) + ");\n")


### PR DESCRIPTION
Now the GUIDs of the metrics sets advertised by the kernel are forwarded
to the web UI along with the metric set ids as read via sysfs. This allows
us to add items to the metric set drop-down menu dynamically.