### PR TITLE
gputop-web-worker: Dynamically add items to the metric set drop-down.

### DIFF
--- a/gputop/gputop-perf.c
+++ b/gputop/gputop-perf.c
@@ -1424,9 +1424,7 @@ gputop_perf_initialize(void)
     } else
 	assert(0);
 
-    gputop_enumerate_queries_via_sysfs();
-
-    return true;
+    return gputop_enumerate_queries_via_sysfs();
 }
 
 static void

--- a/gputop/gputop.proto
+++ b/gputop/gputop.proto
@@ -109,7 +109,7 @@ message Message
  */
 message OAQueryInfo
 {
-    required uint32 metric_set = 1;
+    required string guid = 1;
     //required uint32 format = 2;
     required uint32 period_exponent = 3;
 }

--- a/gputop/web/gputop-ui.js
+++ b/gputop/web/gputop-ui.js
@@ -305,7 +305,7 @@ function open_oa_query_for_trace(idx)
     query_id = next_query_id++;
     rpc({ "method": "open_oa_query",
 	  "params": [ query_id,
-		      oa_query.metric_set,
+		      oa_query.guid,
 		      period_exponent,
 		      false, /* don't overwrite old samples */
 		      100000000, /* nanoseconds of aggregation
@@ -460,7 +460,7 @@ function forensic_ui_activate()
 
     rpc({ "method": "open_oa_query",
 	  "params": [ next_query_id,
-		      1, /* 3D metric set */
+		      oa_query.guid,
 		      period_exponent,
 		      true, /* overwrite old samples */
 		      100, /* milliseconds of aggregation
@@ -614,7 +614,7 @@ function open_oa_query_for_overview(idx)
     query_id = next_query_id++;
     rpc({ "method": "open_oa_query",
 	  "params": [ query_id,
-		      oa_query.metric_set,
+		      oa_query.guid,
 		      period_exponent,
 		      false, /* don't overwrite old samples */
 		      1000000000, /* nanoseconds of aggregation

--- a/gputop/web/gputop-web-worker.c
+++ b/gputop/web/gputop-web-worker.c
@@ -551,7 +551,7 @@ update_features(Gputop__Features *features)
 {
     gputop_string_t *str;
     bool n_queries = 0;
-    struct gputop_hash_entry *entry;
+    int i;
 
     devinfo.devid = features->devinfo->devid;
     devinfo.n_eus = features->devinfo->n_eus;
@@ -584,10 +584,10 @@ update_features(Gputop__Features *features)
     } else
 	assert_not_reached();
 
-    for (entry = gputop_hash_table_next_entry(queries, NULL); entry != NULL;
-         entry = gputop_hash_table_next_entry(queries, entry))
+    for (i = 0; i < features->n_supported_oa_query_guids; i++)
     {
-        struct gputop_perf_query *query = entry->data;
+        struct gputop_perf_query *query = (gputop_hash_table_search(queries,
+            features->supported_oa_query_guids[i]))->data;
 
         if (query->name) {
             if (n_queries)


### PR DESCRIPTION
Items are now added dynamically to the drop-down menu advertising
the available metric sets. This is done by using the array of
GUIDs for sets supported by the kernel derived via sysfs.