### PR TITLE
gputop-perf: check for unexpected OA reason values

### DIFF
--- a/gputop/gputop-perf.h
+++ b/gputop/gputop-perf.h
@@ -57,6 +57,7 @@ typedef enum {
 
 #define OAREPORT_REASON_MASK           0x3f
 #define OAREPORT_REASON_SHIFT          19
+#define OAREPORT_REASON_TIMER          (1<<0)
 #define OAREPORT_REASON_CTX_SWITCH     (1<<3)
 
 struct gputop_devinfo {


### PR DESCRIPTION
We should only be receiving CTX_SWITCH or TIMER based reports, so
for sanity purposes check that this is the case, otherwise log a warning.