### PR TITLE
Fixed fake data and integrated it with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,4 +77,7 @@ before_script:
     - NOCONFIGURE=1 ./autogen.sh
 
 script:
-    - ./configure $CONFIG_OPTS && make
+    - ./configure $CONFIG_OPTS --prefix=$TRAVIS_BUILD_DIR/install && make && make install
+    - export GPUTOP_TRAVIS_MODE
+    - cd $TRAVIS_BUILD_DIR/install/bin
+    - ./gputop --fake ./gputop-system

--- a/gputop/gputop-main.c
+++ b/gputop/gputop-main.c
@@ -95,7 +95,7 @@ usage(void)
 }
 
 #ifdef SUPPORT_GL
-static void
+static bool
 resolve_lib_path_for_env(const char *lib, const char *sym_name, const char *env)
 {
     void *lib_handle;
@@ -106,7 +106,7 @@ resolve_lib_path_for_env(const char *lib, const char *sym_name, const char *env)
     if (!lib_handle) {
         fprintf(stderr, "gputop: Failed to dlopen \"%s\" while trying to resolve a default library path: %s\n",
                 lib, dlerror());
-        exit(1);
+        return false;
     }
 
     sym = dlsym(lib_handle, sym_name);
@@ -129,6 +129,8 @@ resolve_lib_path_for_env(const char *lib, const char *sym_name, const char *env)
                 lib, dlerror());
         exit(1);
     }
+
+    return true;
 }
 #endif
 
@@ -273,8 +275,11 @@ main (int argc, char **argv)
 #ifdef SUPPORT_GL
     env_append_path("LD_PRELOAD", GPUTOP_LIB_DIR "/wrappers/libfakeGL.so");
 
-    if (!getenv("GPUTOP_GL_LIBRARY"))
-	resolve_lib_path_for_env("libGL.so.1", "glClear", "GPUTOP_GL_LIBRARY");
+    if (!getenv("GPUTOP_GL_LIBRARY")) {
+	bool found = resolve_lib_path_for_env("libGL.so.1", "glClear", "GPUTOP_GL_LIBRARY");
+	    if (!found)
+		exit(0);
+    }
 
     if (!getenv("GPUTOP_EGL_LIBRARY"))
 	resolve_lib_path_for_env("libEGL.so.1", "eglGetDisplay", "GPUTOP_EGL_LIBRARY");

--- a/gputop/gputop-perf.c
+++ b/gputop/gputop-perf.c
@@ -1393,6 +1393,48 @@ gputop_enumerate_queries_via_sysfs (void)
     return true;
 }
 
+// function that hard-codes the guids specific for the broadwell configuration
+bool
+gputop_enumerate_queries_fake (void)
+{
+    static const char *fake_bdw_guids[] = {
+        "b541bd57-0e0f-4154-b4c0-5858010a2bf7",
+        "35fbc9b2-a891-40a6-a38d-022bb7057552",
+        "233d0544-fff7-4281-8291-e02f222aff72",
+        "2b255d48-2117-4fef-a8f7-f151e1d25a2c",
+        "f7fd3220-b466-4a4d-9f98-b0caf3f2394c",
+        "e99ccaca-821c-4df9-97a7-96bdb7204e43",
+        "27a364dc-8225-4ecb-b607-d6f1925598d9",
+        "857fc630-2f09-4804-85f1-084adfadd5ab",
+        "343ebc99-4a55-414c-8c17-d8e259cf5e20",
+        "2cf0c064-68df-4fac-9b3f-57f51ca8a069",
+        "78a87ff9-543a-49ce-95ea-26d86071ea93",
+        "9f2cece5-7bfe-4320-ad66-8c7cc526bec5",
+        "d890ef38-d309-47e4-b8b5-aa779bb19ab0",
+        "5fdff4a6-9dc8-45e1-bfda-ef54869fbdd4",
+        "2c0e45e1-7e2c-4a14-ae00-0b7ec868b8aa",
+        "71148d78-baf5-474f-878a-e23158d0265d",
+        "b996a2b7-c59c-492d-877a-8cd54fd6df84",
+        "eb2fecba-b431-42e7-8261-fe9429a6e67a",
+        "60749470-a648-4a4b-9f10-dbfe1e36e44d",
+    };
+
+    struct gputop_perf_query *query;
+    struct gputop_hash_entry *queries_entry;
+
+    int i;
+    int array_length = sizeof(fake_bdw_guids) / sizeof(fake_bdw_guids[0]);
+
+    for (i = 0; i < array_length; i++){
+        queries_entry = gputop_hash_table_search(queries, fake_bdw_guids[i]);
+        query = (struct gputop_perf_query*)queries_entry->data;
+        query->perf_oa_metrics_set = i;
+        array_append(perf_oa_supported_query_guids, &query->guid);
+    }
+
+    return true;
+}
+
 bool
 gputop_perf_initialize(void)
 {
@@ -1431,7 +1473,10 @@ gputop_perf_initialize(void)
     } else
 	assert(0);
 
-    return gputop_enumerate_queries_via_sysfs();
+    if (gputop_fake_mode)
+        return gputop_enumerate_queries_fake();
+    else
+        return gputop_enumerate_queries_via_sysfs();
 }
 
 static void

--- a/gputop/gputop-ui.c
+++ b/gputop/gputop-ui.c
@@ -86,7 +86,7 @@ static int real_stdin;
 static int real_stdout;
 static int real_stderr;
 
-static uv_timer_t timer;
+static uv_timer_t timer, fake_timer;
 static uv_poll_t input_poll;
 static uv_idle_t redraw_idle;
 
@@ -1058,7 +1058,7 @@ redraw_ui(void)
     int i;
 
 #ifdef SUPPORT_GL
-    if (gputop_gl_has_intel_performance_query_ext && !added_gl_tabs) {
+    if (gputop_gl_has_intel_performance_query_ext && !added_gl_tabs && !gputop_fake_mode) {
 	struct tab *switch_to_tab = NULL;
 
 	pthread_rwlock_rdlock(&gputop_gl_lock);
@@ -1324,6 +1324,12 @@ init_ncurses(FILE *infile, FILE *outfile)
     init_pair(GPUTOP_BAR_BAD_COLOR, COLOR_RED, COLOR_BLACK);
 }
 
+static void
+exit_fake_mode_cb(uv_timer_t *timer)
+{
+    exit(0);
+}
+
 void *
 gputop_ui_run(void *arg)
 {
@@ -1406,13 +1412,18 @@ gputop_ui_run(void *arg)
 	current_tab->enter(current_tab);
     }
 
+    if (gputop_fake_mode && gputop_get_bool_env("GPUTOP_TRAVIS_MODE")) {
+        uv_timer_init(gputop_ui_loop, &fake_timer);
+        uv_timer_start(&fake_timer, exit_fake_mode_cb, 5000, 5000);
+    }
+
     uv_run(gputop_ui_loop, UV_RUN_DEFAULT);
 
     gputop_perf_free();
-
     gputop_list_for_each_safe(tab, tmp, &tabs, link) {
         free (tab);
     }
+
 
     return 0;
 }


### PR DESCRIPTION
Added hard-coded broadwell guids for the fake data.
Travis CI will now run gputop with --fake mode for 5 seconds
then halt.