### PR TITLE
Fixed graphs syncronizing the timestamps every 5 seconds

### DIFF
--- a/gputop/remote/ajax/metrics.html
+++ b/gputop/remote/ajax/metrics.html
@@ -2,11 +2,6 @@
 <div id = "header-div">
     <h1 id="page-header-metrics">Metrics panel loading</h1>
 </div>
-<!--
-<div class="btn-group" role="group" aria-label="..." style = "padding-top: 23px; float: none">
-    <button type="button" class="btn btn-default" id = "switch_button">Switch to Live Tracing</button>
-</div>
--->
 
 <!-- Options bar -->
 <div class="well" id="options_bar" style="display: table">
@@ -107,10 +102,11 @@
 
         $("#tab_number_" + set_index).append(counter_bars);
 
-        $('#'+counter_bar_id).css("width", "100%");
-        $('#'+div_id).data(counter);
-        //counter.div_ = $('#'+div_id);
-        $('#' + flot_id).data(counter);
+        $('#' + counter_bar_id).css("width", "100%");
+        $('#' + div_id).data("counter", counter);
+        $('#' + flot_id).data("counter", counter);
+
+        counter.my_first_world_problem = true;
 
         if (!counter.supported_)
             $('#'+counter_bar_id).css("background-color", "#999999");
@@ -165,8 +161,6 @@
 
         $(xml_name).find("set").each(read_metrics_set);
 
-        //$(".glyphicon-collapse-down").hide();
-
         $('#sidebar_right a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
             e.target // newly activated tab
             e.relatedTarget // previous active tab
@@ -179,10 +173,12 @@
                 ("glyphicon-collapse-down", "glyphicon-collapse-up");
 
             $glyphicon.attr("class", glyphicon_class);
-
             var id = $(e.target).find(".well");
-            //graph_start("#" + id.attr("id"));
-            gputop_ui.graph_array.push(id.attr("id"));
+            var counter_id = id.attr("id");
+            var container = "#" + counter_id;
+            var counter = $(container).data("counter");
+            counter.record_data = true;
+            gputop_ui.graph_array.push(counter_id);
         });
 
         $('.collapse').on('hidden.bs.collapse', function(e) {
@@ -191,9 +187,12 @@
                 ("glyphicon-collapse-up", "glyphicon-collapse-down");
 
             $glyphicon.attr("class", glyphicon_class);
-
             var id = $(e.target).find(".well");
             var index = gputop_ui.graph_array.indexOf(id.attr("id")); // get the index of the required element to be removed
+            var container = "#" + gputop_ui.graph_array[index];
+            var counter = $(container).data("counter");
+            counter.record_data = false;
+            counter.graph_data = [];
             gputop_ui.graph_array.splice(index, 1); // remove element from the graph array
         })
 
@@ -209,20 +208,6 @@
     var toggle_mode = 1; // toggle between Overview and Live Tracing metrics
     var i = 0;
     var k = 1;
-
-    $("#switch_button").on("click", function(){
-        if (toggle_mode == 1) {
-            $("#switch_button").text("Switch to Overview");
-            //$('.overview_bars, .progress_text').hide();
-            //$(".glyphicon-collapse-down").show(); // graph dropdown button
-        }
-        else {
-            $("#switch_button").text("Switch to Live Tracing");
-            //$('.overview_bars, .progress_text').show();
-            //$(".glyphicon-collapse-down").hide();
-        }
-        toggle_mode *= -1;
-    });
 
     $('#per_ctx_mode').click(function() {
         var $this = $(this);
@@ -278,12 +263,4 @@
         }
 
     });
-/*
-    var graph_time = 0;
-    setInterval(function call_graph() {
-        graph_time += 200;
-        gputop_ui.display_graph(10000000 * graph_time)
-    }, 200);
-*/
-
 </script>

--- a/gputop/remote/gputop.js
+++ b/gputop/remote/gputop.js
@@ -59,16 +59,16 @@ function Counter () {
     this.data_ = [];
     this.updates = [];
     this.graph_data = [];
+    this.record_data = false;
 }
 
 Counter.prototype.append_counter_data = function (start_timestamp, end_timestamp, delta, d_value, max) {
-     if (max != 0) {
-        var current_delta = 0;
+     if (this.record_data && max != 0) {
         var value = 100 * d_value / max;
 
         this.updates.push([start_timestamp, end_timestamp, value]);
 
-        if (this.updates.length > 1000) {
+        if (this.updates.length > 2000) {
             this.updates.shift();
         }
     }
@@ -83,9 +83,6 @@ Counter.prototype.append_counter_data = function (start_timestamp, end_timestamp
 
     this.last_value_ = d_value;
     this.invalidate_ = true;
-
-    //if (max != 0)
-    //    console.log(" NSamples " + n_samples + " COUNTER ["+start_timestamp+":"+ end_timestamp +"]:"+delta+" = "+ d_value + "/" + max +" Data " + this.symbol_name);
 
     this.data_.push(delta, d_value, max);
 
@@ -383,10 +380,10 @@ Gputop.prototype.open_oa_query_for_trace = function(guid) {
     open.id = metric.oa_query_id_; // oa_query ID
     open.overwrite = false;   /* don't overwrite old samples */
     open.live_updates = true; /* send live updates */
-                         /* nanoseconds of aggregation
-				          * i.e. request updates from the worker
-				          * as values that have been aggregated
-				          * over this duration */
+                              /* nanoseconds of aggregation
+                               * i.e. request updates from the worker
+                               * as values that have been aggregated
+                               * over this duration */
 
     open.per_ctx_mode = metric.is_per_ctx_mode();
     open.oa_query = oa_query;
@@ -476,8 +473,8 @@ Gputop.prototype.generate_uuid = function()
      * http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
      */
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    	var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
-    	return v.toString(16);
+        var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+        return v.toString(16);
     });
 }
 


### PR DESCRIPTION
- data is not being added anymore to the counter's updates array when
graphs are closed, saving some performance.

- the javascript timestamps and counter's timestamps are now syncronizing
every 5 seconds, as before the graph would have gaps after few minutes
due to the counter's timestamps running slower. As a result, the graph now looks
smooth.

- cleaned up some code in metrics.html