### PR TITLE
web-ui: Removing the reply uuid from the close notification

### DIFF
--- a/gputop/gputop-server.c
+++ b/gputop/gputop-server.c
@@ -197,6 +197,7 @@ send_pb_message(h2o_websocket_conn_t *conn, ProtobufCMessage *pb_message)
 static void
 stream_closed_cb(struct gputop_perf_stream *stream)
 {
+    Gputop__Message message_ack = GPUTOP__MESSAGE__INIT;
     Gputop__Message message = GPUTOP__MESSAGE__INIT;
     Gputop__CloseNotify notify = GPUTOP__CLOSE_NOTIFY__INIT;
 
@@ -205,13 +206,13 @@ stream_closed_cb(struct gputop_perf_stream *stream)
      * ACK... */
     if (stream->user.data) {
 
-        message.reply_uuid = stream->user.data;
-        message.cmd_case = GPUTOP__MESSAGE__CMD_ACK;
-        message.ack = true;
+        message_ack.reply_uuid = stream->user.data;
+        message_ack.cmd_case = GPUTOP__MESSAGE__CMD_ACK;
+        message_ack.ack = true;
 
         dbg("CMD_ACK: %s\n", (char *)stream->user.data);
 
-        send_pb_message(h2o_conn, &message.base);
+        send_pb_message(h2o_conn, &message_ack.base);
 
         free(stream->user.data);
         stream->user.data = NULL;
@@ -981,6 +982,8 @@ static void on_connect(uv_stream_t *server, int status)
 
     if (status != 0)
         return;
+
+    signal(SIGPIPE, SIG_IGN);
 
     conn = h2o_mem_alloc(sizeof(*conn));
     uv_tcp_init(server->loop, conn);


### PR DESCRIPTION
The reply message will crash the system since the memory
containing the uuid is being freed when the stream is closed.

This patch is a different implementation, just nullifying the
Reply uuid which i don't think is necessary on that callback.

==22225== Invalid read of size 2
==22225==    at 0x4C2F7EF: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22225==    by 0x6954EFE: string_pack (protobuf-c.c:920)
==22225==    by 0x69552A8: required_field_pack (protobuf-c.c:1045)
==22225==    by 0x6955454: optional_field_pack (protobuf-c.c:1120)
==22225==    by 0x6955B45: protobuf_c_message_pack (protobuf-c.c:1398)
==22225==    by 0x4F31F14: send_pb_message (gputop-server.c:186)
==22225==    by 0x4F3208B: stream_closed_cb (gputop-server.c:225)
==22225==    by 0x4F28313: finish_stream_close (gputop-perf.c:288)
==22225==    by 0x4F2835D: stream_handle_closed_cb (gputop-perf.c:297)
==22225==    by 0x4F3ADD8: uv__finish_close (core.c:245)
==22225==    by 0x4F3AE1E: uv__run_closing_handles (core.c:259)
==22225==    by 0x4F3B00A: uv_run (core.c:325)
==22225==  Address 0xd1bb8d4 is 4 bytes inside a block of size 37 free'd
==22225==    at 0x4C2BDEC: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22225==    by 0x4F3204A: stream_closed_cb (gputop-server.c:216)
==22225==    by 0x4F28313: finish_stream_close (gputop-perf.c:288)
==22225==    by 0x4F2835D: stream_handle_closed_cb (gputop-perf.c:297)
==22225==    by 0x4F3ADD8: uv__finish_close (core.c:245)
==22225==    by 0x4F3AE1E: uv__run_closing_handles (core.c:259)
==22225==    by 0x4F3B00A: uv_run (core.c:325)
==22225==    by 0x4F2F7B7: gputop_ui_run (gputop-ui.c:1684)
==22225==    by 0x6B65181: start_thread (pthread_create.c:312)
==22225==    by 0x5E1F47C: clone (clone.S:111)