### PR TITLE
gputop-ui: fix current_tab reset flow

### DIFF
--- a/gputop/gputop-ui.c
+++ b/gputop/gputop-ui.c
@@ -203,8 +203,6 @@ i915_perf_oa_overview_open(struct gputop_perf_query *query,
 static void
 overview_closed_cb(struct gputop_perf_stream *stream)
 {
-    current_tab = NULL;
-
     gputop_perf_stream_unref(gputop_current_perf_stream);
     gputop_current_perf_stream = NULL;
     gputop_current_perf_query = NULL;
@@ -213,6 +211,8 @@ overview_closed_cb(struct gputop_perf_stream *stream)
 static void
 i915_perf_oa_overview_close(void)
 {
+    current_tab = NULL;
+
     if (!gputop_current_perf_stream)
         return;
 
@@ -315,8 +315,6 @@ gputop_i915_perf_oa_trace_open(struct gputop_perf_query *query,
 static void
 trace_closed_cb(struct gputop_perf_stream *stream)
 {
-    current_tab = NULL;
-
     gputop_perf_stream_unref(gputop_current_perf_stream);
 
     free(gputop_perf_trace_buffer);
@@ -327,6 +325,8 @@ trace_closed_cb(struct gputop_perf_stream *stream)
 void
 gputop_i915_perf_oa_trace_close(void)
 {
+    current_tab = NULL;
+
     if (!gputop_current_perf_stream)
         return;
 


### PR DESCRIPTION
When closing a tab we should always reset the current_tab, regardless of
the value of gputop_current_perf_stream, otherwise we can get stuck with
the ui not drawing the pending_tab for GL queries, since GL queries
don't affect the value of gputop_current_perf_stream. This is only
applicable when running with perf.paranoid enabled.