### PR TITLE
gputop.js: Load .proto file via a HTTP request.

### DIFF
--- a/gputop/remote/gputop.js
+++ b/gputop/remote/gputop.js
@@ -40,8 +40,21 @@ if (typeof dcodeIO === 'undefined' || !dcodeIO.ProtoBuf) {
 }
 // Initialize ProtoBuf.js
 var ProtoBuf = dcodeIO.ProtoBuf;
+var proto_builder;
+var gputop;
 
-var proto_builder = ProtoBuf.loadProtoFile("gputop.proto");
+var xmlHttp = new XMLHttpRequest();
+xmlHttp.onreadystatechange = function() {
+    if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
+        proto_builder = ProtoBuf.newBuilder();
+        ProtoBuf.protoFromString(xmlHttp.responseText, proto_builder,
+            "gputop.proto");
+        gputop = new Gputop();
+    }
+}
+
+xmlHttp.open("GET", "http://localhost:7890/gputop.proto", true);
+xmlHttp.send(null);
 
 //----------------------------- COUNTER --------------------------------------
 function Counter () {
@@ -673,5 +686,3 @@ Gputop.prototype.connect = function() {
     //----------------- Data transactions ----------------------
     this.socket_ = this.get_socket(websocket_url);
 }
-
-var gputop = new Gputop();


### PR DESCRIPTION
Since the nodejs code loads the .proto file via
a HTTP request it makes sense do the same here.
