### PR TITLE
Fixed fake-mode working with the new web-ui - v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,9 @@ before_install:
     - export PKG_CONFIG_PATH="$TRAVIS_BUILD_DIR/protobuf/lib/pkgconfig"
     # Fetch glext.h header including INTEL_performance_query enums
     - $(mkdir GL && cd GL && wget https://raw.githubusercontent.com/rib/mesa/wip/rib/oa-next/include/GL/glext.h)
+    - "export DISPLAY=:99.0"
+    - "sh -e /etc/init.d/xvfb start"
+    - sleep 3
 
 before_script:
     - NOCONFIGURE=1 ./autogen.sh
@@ -81,3 +84,4 @@ script:
     - export GPUTOP_TRAVIS_MODE=1
     - cd $TRAVIS_BUILD_DIR/install/bin
     - ./gputop --fake ./gputop-system
+    - if [ "${CONFIG_OPTS/'enable-webui'}" != "$CONFIG_OPTS" ]; then ./gputop --fake --remote ./gputop-system 2> travis_log& sleep 3; firefox http://localhost:7890& sleep 10; grep OpenQuery travis_log; cat travis_log; fi

--- a/gputop/gputop-perf.c
+++ b/gputop/gputop-perf.c
@@ -1491,7 +1491,7 @@ gputop_perf_initialize(void)
         return true;
     if (getenv("GPUTOP_FAKE_MODE") && strcmp(getenv("GPUTOP_FAKE_MODE"), "1") == 0) {
         gputop_fake_mode = true;
-        intel_dev.device = 0;
+        intel_dev.device = 5654; // broadwell specific id
     }
     else {
         drm_fd = open_render_node(&intel_dev);
@@ -1509,9 +1509,7 @@ gputop_perf_initialize(void)
                                        gputop_key_string_equal);
     perf_oa_supported_query_guids = array_new(sizeof(char*), 1);
 
-    if (gputop_fake_mode) {
-        gputop_oa_add_queries_bdw(&gputop_devinfo);
-    } else if (IS_HASWELL(intel_dev.device)) {
+    if (IS_HASWELL(intel_dev.device)) {
         gputop_oa_add_queries_hsw(&gputop_devinfo);
     } else if (IS_BROADWELL(intel_dev.device)) {
         gputop_oa_add_queries_bdw(&gputop_devinfo);

--- a/gputop/gputop-ui.c
+++ b/gputop/gputop-ui.c
@@ -1703,7 +1703,7 @@ gputop_ui_run(void *arg)
 
     if (gputop_fake_mode && gputop_get_bool_env("GPUTOP_TRAVIS_MODE")) {
         uv_timer_init(gputop_ui_loop, &fake_timer);
-        uv_timer_start(&fake_timer, exit_fake_mode_cb, 5000, 5000);
+        uv_timer_start(&fake_timer, exit_fake_mode_cb, 10000, 10000);
     }
 
     uv_run(gputop_ui_loop, UV_RUN_DEFAULT);


### PR DESCRIPTION
- now the devid in fake mode is associated with a Broadwell ID instead of 0

- travis now runs the fake mode with the web ui, launches firefox on the required port, and outputs the messages in travis_log. This is then grep'ed and looked for a specific substring that tells us it ran successfully.