### PR TITLE
gputop-nodejs: Creates Node.js tooling infrastructure.

### DIFF
--- a/gputop/gputop-main.c
+++ b/gputop/gputop-main.c
@@ -60,7 +60,7 @@ usage(void)
 #endif
 #ifdef SUPPORT_WEBUI
     printf("     --remote                      Enable remote web-based interface\n\n");
-    printf("     --nodejs                      Enable remote nodejs-based interface\n\n");
+    printf("     --nodejs                      Enable remote nodejs-based tool\n\n");
 #endif
     printf(" -h, --help                        Display this help\n\n"
            "\n"
@@ -208,7 +208,7 @@ main (int argc, char **argv)
 #endif
 #ifdef SUPPORT_WEBUI
         {"remote",          no_argument,        0, REMOTE_OPT},
-        {"nodejs",          no_argument,        0, NODEJS_OPT},
+        {"nodejs",          optional_argument,  0, NODEJS_OPT},
 #endif
         {0, 0, 0, 0}
     };
@@ -258,6 +258,9 @@ main (int argc, char **argv)
                 break;
             case NODEJS_OPT:
                 setenv("GPUTOP_MODE", "nodejs", true);
+
+                if (optarg)
+                    setenv("GPUTOP_NODEJS_TOOL", optarg, true);
                 break;
 #endif
             default:

--- a/gputop/gputop-ui.c
+++ b/gputop/gputop-ui.c
@@ -1674,13 +1674,17 @@ gputop_ui_run(void *arg)
 
     } else if (nodejs_ui) {
         pid_t pid;
+        char *tool = getenv("GPUTOP_NODEJS_TOOL");
+
+        if (!tool)
+            tool = "features";
 
         gputop_server_run();
         pid = fork();
 
         if (pid != 0) {
             char *exec_args[] = { "node",
-                GPUTOP_NODEJS_ROOT "/gputop-nodejs-ui.js", NULL };
+                GPUTOP_NODEJS_ROOT "/gputop-nodejs-toolkit.js", tool, NULL };
             int i, err;
 
             unsetenv("LD_PRELOAD");

--- a/gputop/remote/Makefile.am
+++ b/gputop/remote/Makefile.am
@@ -37,7 +37,8 @@ nobase_dist_remote_DATA = \
 
 nodejsdir = $(libdir)/nodejs/gputop
 nobase_dist_nodejs_DATA = \
-gputop-nodejs-ui.js
+gputop-nodejs-ui.js \
+gputop-nodejs-toolkit.js
 
 nodemodulesdir = $(libdir)/nodejs/gputop
 nobase_dist_nodemodules_DATA := \

--- a/gputop/remote/gputop-nodejs-toolkit.js
+++ b/gputop/remote/gputop-nodejs-toolkit.js
@@ -1,0 +1,17 @@
+const fork = require('child_process').fork;
+var child;
+var js_file = __dirname + "/gputop-nodejs-ui";
+
+if (process.argv.length >= 3) {
+    switch(process.argv[2]) {
+        case "features":
+            console.log("gputop: Launching features tool.\n");
+            break;
+        default:
+            console.error("gputop: Unrecognized tool: " + process.argv[2] +
+                      ". Launching features tool.\n");
+            break;
+    }
+}
+
+child = fork(js_file);


### PR DESCRIPTION
Creates the basic mechanism for managing multiple Node.js tools.
Now gputop can be launched by passing an optional argument to
--nodejs which is the name of the Node.js tool.