### PR TITLE
Fixed xml parsing before metrics.html loads.

### DIFF
--- a/gputop/remote/gputop-ui.js
+++ b/gputop/remote/gputop-ui.js
@@ -331,12 +331,18 @@ GputopUI.prototype.update_features = function(features) {
     if (features.get_fake_mode())
         $( "#metrics-tab-a" ).html("Metrics (Fake Mode) ");
 
-    gputop_ui.load_metrics_panel(function() {
-        var metric = gputop.get_map_metric(global_guid);
+    // read counters from xml file and populate the website
+    gputop.xml_file_name_ = gputop.config_.architecture +".xml";
+    console.log(gputop.config_.architecture);
+    $.get(gputop.xml_file_name_, function(xml) {
+        gputop.parse_xml_metrics(xml);
+        gputop_ui.load_metrics_panel(function() {
+            var metric = gputop.get_map_metric(global_guid);
 
-        update_metric_period_exponent_for_zoom(metric);
+            update_metric_period_exponent_for_zoom(metric);
 
-        gputop.open_oa_query_for_trace(global_guid);
+            gputop.open_oa_query_for_trace(global_guid);
+        });
     });
 }
 

--- a/gputop/remote/gputop-web.c
+++ b/gputop/remote/gputop-web.c
@@ -362,20 +362,20 @@ update_features(uint32_t devid,
     metrics = gputop_hash_table_create(NULL, gputop_key_hash_string,
                                        gputop_key_string_equal);
     if (IS_HASWELL(devid)) {
-        _gputop_web_console_log("Adding Haswell metrics\n");
-        emscripten_run_script("gputop.load_oa_metrics('hsw');");
+        _gputop_web_console_log("Adding Haswell queries\n");
+        emscripten_run_script("gputop.set_architecture('hsw');");
         gputop_oa_add_metrics_hsw(&gputop_devinfo);
     } else if (IS_BROADWELL(devid)) {
-        _gputop_web_console_log("Adding Broadwell metrics\n");
-        emscripten_run_script("gputop.load_oa_metrics('bdw');");
+        _gputop_web_console_log("Adding Broadwell queries\n");
+        emscripten_run_script("gputop.set_architecture('bdw');");
         gputop_oa_add_metrics_bdw(&gputop_devinfo);
     } else if (IS_CHERRYVIEW(devid)) {
-        _gputop_web_console_log("Adding Cherryview metrics\n");
+        _gputop_web_console_log("Adding Cherryview queries\n");
         gputop_oa_add_metrics_chv(&gputop_devinfo);
-        emscripten_run_script("gputop.load_oa_metrics('chv');");
+        emscripten_run_script("gputop.set_architecture('chv');");
     } else if (IS_SKYLAKE(devid)) {
-        _gputop_web_console_log("Adding Skylake metrics\n");
-        emscripten_run_script("gputop.load_oa_metrics('skl');");
+        _gputop_web_console_log("Adding Skylake queries\n");
+        emscripten_run_script("gputop.set_architecture('skl');");
         gputop_oa_add_metrics_skl(&gputop_devinfo);
     } else
         assert_not_reached();

--- a/gputop/remote/gputop.js
+++ b/gputop/remote/gputop.js
@@ -394,7 +394,7 @@ Gputop.prototype.stream_update_counter = function (counterId,
                                 d_value, max, reason);
 }
 
-Gputop.prototype.load_xml_metrics = function(xml) {
+Gputop.prototype.parse_xml_metrics = function(xml) {
     gputop.metrics_xml_ = xml;
     $(xml).find("set").each(gputop_read_metrics_set);
 }
@@ -413,12 +413,9 @@ Gputop.prototype.load_fake_metrics = function(architecture) {
     this.load_oa_metrics(architecture);
 }
 
-Gputop.prototype.load_oa_metrics = function(architecture) {
+
+Gputop.prototype.set_architecture = function(architecture) {
     this.config_.architecture = architecture;
-    // read counters from xml file and populate the website
-    gputop.xml_file_name_ = architecture +".xml";
-    console.log(architecture);
-    $.get(gputop.xml_file_name_, this.load_xml_metrics);
 }
 
 Gputop.prototype.update_period = function(guid, period_ns) {


### PR DESCRIPTION
- Fixed a bug where the metrics.html loading and xml parsing were
parallelised, which could end in metrics loading faster, and therefore
it wouldn't know the xml. These are now happening in a sequential order.
