### PR TITLE
Fix gputop crash on start

### DIFF
--- a/gputop/gputop-main.c
+++ b/gputop/gputop-main.c
@@ -281,7 +281,7 @@ get_gputop_system_path(void)
         NULL
     };
 
-    for (int i; options[i]; i++) {
+    for (int i = 0; options[i]; i++) {
         struct stat sb;
         char *path = NULL;
 


### PR DESCRIPTION
Fix loop counter initialization.

Signed-off-by: Zhenyu Wang zhenyuw@linux.intel.com
