### PR TITLE
fix the overview page loading issue on the web-ui

### DIFF
--- a/gputop-client/gputop.js
+++ b/gputop-client/gputop.js
@@ -1476,7 +1476,7 @@ Gputop.prototype.process_features = function(features){
             cc._gputop_cc_set_system_property(name_c_string, val);
             break;
         case "string":
-            val = features.devinfo[field.name];
+            val = String_pointerify_on_stack(features.devinfo[field.name]);
             cc._gputop_cc_set_system_property_string(name_c_string, val);
             break;
         default:


### PR DESCRIPTION
For the latest commit 5632201f1a5f40a0bbd2f47feb959c1b8ea1b6ed on the master branch, when running gputop, the web-ui can’t work normally, that is, the overview page cannot be loaded, this following commit can fix the issue.