### PR TITLE
fix counter filtering and gprph plotting issues when one metric set is selected again

### DIFF
--- a/gputop-webui/gputop-ui.js
+++ b/gputop-webui/gputop-ui.js
@@ -290,6 +290,8 @@ GputopUI.prototype.select_metric_set = function(metric) {
     for (var i = 0; i < metric.cc_counters.length; i++) {
         var counter = metric.cc_counters[i];
         var counter_row_id = "row_" + metric.underscore_name + '_' + counter.underscore_name;
+        counter.record_data = false;
+        counter.zero = true;
         var select_marker_id = counter_row_id + "_marker";
         var bar_id = counter_row_id + "_bar";
         var txt_value_id = counter_row_id + "_value";
@@ -529,7 +531,7 @@ GputopUI.prototype.update_gpu_metrics_graph = function (timestamp) {
         if (first.counter.record_data === true)
             break;
     }
-    if (!first)
+    if (!first.counter.record_data)
         return;
 
     var n_updates = first.updates.length;


### PR DESCRIPTION
When one metric set is selected at first, for example,  Render Metrics Basic Gen9, and open a graph for one counter, such as Sampler Texels. Now you select another metric set without closing the graph. But when you back to the Render Metrics Basic Gen9 again, the graph for the Sampler Texels still shows on the web, which should be removed. 

In the same way, when you back to the Render Metrics Basic Gen9 again, there is no counter filtering process all of the counters are presented on the web. It is because the function GputopUI.prototype.filter_counters has not be called.