### PR TITLE
support for per-vGPU mode profiling

### DIFF
--- a/gputop-client-c/gputop-client-c-bindings.cpp
+++ b/gputop-client-c/gputop-client-c-bindings.cpp
@@ -115,6 +115,8 @@ gputop_cc_handle_i915_perf_message_binding(const v8::FunctionCallbackInfo<Value>
     struct gputop_cc_stream *stream = (struct gputop_cc_stream *)ptr->ptr_;
 
     unsigned int len = args[2]->NumberValue();
+    unsigned int ctx_hw_id = args[5]->NumberValue();
+    unsigned int idle_flag = args[6]->NumberValue();
 
     if (!args[1]->IsArrayBufferView()) {
         isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Expected 2nd argument to be an ArrayBufferView")));
@@ -167,7 +169,9 @@ gputop_cc_handle_i915_perf_message_binding(const v8::FunctionCallbackInfo<Value>
                                        static_cast<uint8_t *>(data_contents.Data()) + offset,
                                        len,
                                        accumulators,
-                                       n_accumulators);
+                                       n_accumulators,
+                                       ctx_hw_id,
+                                       idle_flag);
 }
 
 void

--- a/gputop-client-c/gputop-client-c-runtime-bindings.cpp
+++ b/gputop-client-c/gputop-client-c-runtime-bindings.cpp
@@ -160,5 +160,15 @@ _gputop_cr_accumulator_end_update(void)
     fn->Call(gputop, ARRAY_LENGTH(argv), argv);
 }
 
+void
+_gputop_cr_send_idle_flag(int idle_flag)
+{
+    Isolate* isolate = Isolate::GetCurrent();
+    HandleScope scope(isolate);
 
+    Local<Object> gputop = Local<Object>::New(isolate, gputop_cc_singleton);
+    Local<Function> fn = Local<Function>::Cast(gputop->Get(String::NewFromUtf8(isolate, "send_idle_flag")));
 
+    Local<Value> argv[] = {Number::New(isolate, idle_flag)};
+    fn->Call(gputop, ARRAY_LENGTH(argv), argv);
+}

--- a/gputop-client-c/gputop-client-c-runtime.h
+++ b/gputop-client-c/gputop-client-c-runtime.h
@@ -66,7 +66,7 @@ bool _gputop_cr_accumulator_start_update(struct gputop_cc_stream *stream,
 void _gputop_cr_accumulator_append_count(int counter,
                                          double max, double value);
 void _gputop_cr_accumulator_end_update(void);
-
+void _gputop_cr_send_idle_flag(int idle_flag);
 #ifdef __cplusplus
 }
 #endif

--- a/gputop-client-c/gputop-client-c.h
+++ b/gputop-client-c/gputop-client-c.h
@@ -92,7 +92,9 @@ int gputop_cc_get_counter_id(const char *guid, const char *counter_symbol_name);
 void gputop_cc_handle_i915_perf_message(struct gputop_cc_stream *stream,
                                         uint8_t *data, int data_len,
                                         struct gputop_cc_oa_accumulator **accumulators,
-                                        int n_accumulators);
+                                        int n_accumulators,
+                                        int ctx_hw_id,
+                                        int idle_flag);
 
 void gputop_cc_reset_system_properties(void);
 void gputop_cc_set_system_property(const char *name, double value);

--- a/gputop-client-c/gputop-web-lib.js
+++ b/gputop-client-c/gputop-web-lib.js
@@ -93,6 +93,13 @@ var LibraryGpuTopWeb = {
         else
             console.error("Gputop singleton not initialized");
     },
+    _gputop_cr_send_idle_flag: function(idle_flag) {
+    var gputop = Module['gputop_singleton'];
+        if (gputop !== undefined)
+            gputop.send_idle_flag.call(gputop, idle_flag);
+        else
+            console.error("Gputop singleton not initialized");
+    },
 };
 
 autoAddDeps(LibraryGpuTopWeb, '$GPUTop');

--- a/gputop-client/gputop.js
+++ b/gputop-client/gputop.js
@@ -30,6 +30,11 @@
 var is_nodejs = false;
 var using_emscripten = true;
 
+var ctx_hw_id_ = [];
+var vgpu_id_ = [];
+var ctx_mode=['Global'];
+var map_vgpuID_hwID = [0];
+
 if (typeof module !== 'undefined' && module.exports) {
 
     var WebSocket = require('ws');
@@ -737,6 +742,7 @@ Gputop.prototype.set_demo_architecture = function(architecture) {
 
     this.demo_architecture = architecture;
     this.is_connected_ = true;
+    this.request_hw_id_map();
     this.request_features();
 }
 
@@ -1383,6 +1389,16 @@ Gputop.prototype.rpc_request = function(method, value, closure) {
     }
 }
 
+Gputop.prototype.request_hw_id_map = function() {
+    if (!this.is_demo()) {
+        if (this.socket_.readyState == is_nodejs ? 1 : WebSocket.OPEN) {
+            this.rpc_request('get_hw_id_map', true);
+        } else {
+            this.log("Can't request context hardware ID map while not connected", this.ERROR);
+        }
+    }
+}
+
 Gputop.prototype.request_features = function() {
     if (!this.is_demo()) {
         if (this.socket_.readyState == is_nodejs ? 1 : WebSocket.OPEN) {
@@ -1671,6 +1687,9 @@ function gputop_socket_on_message(evt) {
                 stream.dispatchEvent(ev);
             }
             break;
+        case 'hw_id':
+            this.update_vgpuID_hwID(msg.hw_id);
+            break;
         }
 
         if (msg.reply_uuid in this.rpc_closures_) {
@@ -1824,6 +1843,7 @@ Gputop.prototype.connect = function(address, onopen, onclose, onerror) {
                 this.log('Connecting to ' + websocket_url);
                 this.socket_ = this.connect_web_socket(websocket_url, () => { //onopen
                     this.is_connected_ = true;
+                    this.request_hw_id_map();
                     this.request_features();
 
                     var ev = { type: "open" };
@@ -1839,6 +1859,7 @@ Gputop.prototype.connect = function(address, onopen, onclose, onerror) {
                 });
             } else {
                 this.is_connected_ = true;
+                this.request_hw_id_map();
                 this.request_features();
 
                 var ev = { type: "open" };

--- a/gputop-client/gputop.js
+++ b/gputop-client/gputop.js
@@ -484,7 +484,7 @@ Gputop.prototype.clear_accumulated_metrics = function(metric) {
     }
 }
 
-Gputop.prototype.replay_i915_perf_history = function(metric) {
+Gputop.prototype.replay_i915_perf_history = function(metric, hw_id) {
     this.clear_accumulated_metrics(metric);
 
     var stream = metric.stream;
@@ -520,7 +520,9 @@ Gputop.prototype.replay_i915_perf_history = function(metric) {
                                                        stack_data,
                                                        data.length,
                                                        vec,
-                                                       n_accumulators);
+                                                       n_accumulators,
+                                                       hw_id,
+                                                       this.idle_flag);
         } else {
             var vec = [];
             for (var j = 0; j < n_accumulators; j++) {
@@ -532,7 +534,9 @@ Gputop.prototype.replay_i915_perf_history = function(metric) {
                                                    stack_data,
                                                    data.length,
                                                    vec,
-                                                   n_accumulators);
+                                                   n_accumulators,
+                                                   hw_id,
+                                                   this.idle_flag);
         }
 
         cc.Runtime.stackRestore(sp);
@@ -667,6 +671,10 @@ Gputop.prototype.accumulator_end_update = function () {
     this.notify_accumulator_events(metric,
                                    update.accumulator,
                                    update.events_mask);
+}
+
+Gputop.prototype.send_idle_flag = function (idle_flag) {
+    this.idle_flag = idle_flag;
 }
 
 Gputop.prototype.accumulator_clear = function (accumulator) {
@@ -1739,7 +1747,9 @@ function gputop_socket_on_message(evt) {
                                                            stack_data,
                                                            data.length,
                                                            vec,
-                                                           n_accumulators);
+                                                           n_accumulators,
+                                                           this.current_hw_id,
+                                                           this.idle_flag);
             } else {
                 var vec = [];
                 for (var i = 0; i < n_accumulators; i++) {
@@ -1751,7 +1761,9 @@ function gputop_socket_on_message(evt) {
                                                        stack_data,
                                                        data.length,
                                                        vec,
-                                                       n_accumulators);
+                                                       n_accumulators,
+                                                       this.current_hw_id,
+                                                       this.idle_flag);
             }
 
             cc.Runtime.stackRestore(sp);

--- a/gputop-csv/gputop-csv.js
+++ b/gputop-csv/gputop-csv.js
@@ -59,6 +59,8 @@ function GputopCSV(pretty_print)
     this.endl = process.platform === "win32" ? "\r\n" : "\n";
 
     this.term_row_ = 0;
+    this.current_hw_id = 0;
+    this.idle_flag = 0;
 
     this.console = {
         log: (msg) => {
@@ -132,6 +134,59 @@ GputopCSV.prototype.list_metric_set_counters = function(metric) {
         all += counter.symbol_name;
     });
     stderr_log.log("\nALL: " + all);
+}
+
+var ctx_hw_id_ = [];
+var vgpu_id_ = [];
+var map_vgpuID_hwID = [0];
+
+GputopCSV.prototype.get_vgpu_id = function() {
+    var vgpu_id;
+    for (var i = 0; i < vgpu_id_.length; i++) {
+        if (vgpu_id_[i] === parseInt(args.vgpu)) {
+            vgpu_id = vgpu_id_[i];
+                 break;
+        }
+    }
+    return vgpu_id;
+}
+
+GputopCSV.prototype.update_vgpuID_hwID = function(hw_id) {
+
+    hw_id.ctx_hw_id.forEach((ctx_hw_id, i) => {
+         ctx_hw_id_.push(ctx_hw_id.toInt());
+    });
+    hw_id.vgpu_id.forEach((vgpu_id, i) => {
+         vgpu_id_.push(vgpu_id.toInt());
+    });
+
+
+    var map_length = Math.max.apply(Math, vgpu_id_);
+
+    for (var i = 0; i < map_length; i++ ) {
+         map_vgpuID_hwID[vgpu_id_[i]] = ctx_hw_id_[i];
+    }
+    vgpu_id_.sort();
+
+    if (args.vgpu === 'list') {
+        if (vgpu_id_.length === 0) {
+            stderr_log.log("\nNo vGPU is running now!");
+        } else {
+            stderr_log.log("\nList of vGPU ID selectable with --vgpu=...");
+            for (var i = 0; i < vgpu_id_.length; i++)
+                stderr_log.log(vgpu_id_[i]);
+        }
+    } else {
+        var vgpu_id;
+        vgpu_id = this.get_vgpu_id();
+        this.current_hw_id = map_vgpuID_hwID[vgpu_id];
+
+        if (this.current_hw_id === undefined) {
+            stderr_log.error("Failed to look up to vGPU ID " + args.vgpu);
+            process.exit(1);
+            return;
+        }
+    }
 }
 
 GputopCSV.prototype.update_features = function(features)
@@ -241,6 +296,7 @@ GputopCSV.prototype.update_features = function(features)
             var col_width = 0;
 
             if (this.pretty_print_csv_) {
+
                 if (counter.symbol_name === "Timestamp") {
                     var units = "(ns)";
                     var camel_name = "TimeStamp";
@@ -350,6 +406,7 @@ GputopCSV.prototype.update_features = function(features)
                             this.column_titles_.map((line) => {
                                 this.stream.write(line + this.endl);
                             });
+
                             if (this.pretty_print_csv_)
                                 this.stream.write(this.column_units_ + this.endl);
                         },
@@ -361,6 +418,8 @@ GputopCSV.prototype.update_features = function(features)
         stderr_log.error("Failed to find counters matching requested columns");
     }
 }
+
+var n_rows;
 
 function write_rows(metric, accumulator)
 {
@@ -375,7 +434,7 @@ function write_rows(metric, accumulator)
     stderr_log.assert(ref_accumulated_counter.counter === ref_counter,
                "Spurious reference counter state");
 
-    var n_rows = ref_accumulated_counter.updates.length;
+    n_rows = ref_accumulated_counter.updates.length;
 
     if (n_rows <= 1)
         return;
@@ -456,6 +515,8 @@ function write_rows(metric, accumulator)
     }
 }
 
+var flag = 0;
+
 GputopCSV.prototype.notify_accumulator_events = function(metric, accumulator, events_mask) {
     if (events_mask & 1) //period elapsed
         this.accumulator_clear(accumulator);
@@ -463,12 +524,33 @@ GputopCSV.prototype.notify_accumulator_events = function(metric, accumulator, ev
     if (this.write_queued_)
         return;
 
-    setTimeout(() => {
-        this.write_queued_ = false;
-        write_rows.call(this, metric, accumulator);
-    }, 0.2);
+    if (this.idle_flag < 4) {
+        flag = 0;
+        setTimeout(() => {
+            this.write_queued_ = false;
+            write_rows.call(this, metric, accumulator);
+        }, 0.2);
 
-    this.write_queued_ = true;
+        this.write_queued_ = true;
+    } else {
+        if (flag === 0) {
+            flag = 1;
+            if (this.pretty_print_csv_)
+                stderr_log.error("No context is running on this vGPU now");
+            else
+                this.stream.write("No context is running on this vGPU now\n");
+        }
+
+        for (var c = 0; c < this.counters_.length; c++) {
+            var counter = this.counters_[c];
+            if (counter.record_data === true) {
+                var accumulated_counter =
+                    accumulator.accumulated_counters[counter.cc_counter_id_];
+                n_rows = 2;
+                accumulated_counter.updates.splice(0, n_rows);
+            }
+        }
+    }
 }
 
 var parser = new ArgumentParser({
@@ -482,6 +564,16 @@ parser.addArgument(
     {
         help: 'host:port to connect to (default localhost:7890)',
         defaultValue: 'localhost:7890'
+    }
+);
+
+parser.addArgument(
+    [ '-vgpu', '--vgpu' ],
+    {
+        help: "specific vgpu mode to observe (default 'list')",
+        defaultValue: 'list',
+        constant: 'list',
+        nargs: '?'
     }
 );
 

--- a/gputop-data/gputop.proto
+++ b/gputop-data/gputop.proto
@@ -134,6 +134,11 @@ message TracepointInfo
     required string sample_format = 2;
 }
 
+message HW_ID
+{
+    repeated uint64 ctx_hw_id = 1;
+    repeated uint64 vgpu_id = 2;
+}
 
 message Message
 {
@@ -149,6 +154,7 @@ message Message
         ProcessInfo process_info = 8;
         CpuStatsSet cpu_stats = 9;
         TracepointInfo tracepoint_info = 10;
+        HW_ID hw_id = 11;
     }
 }
 
@@ -210,5 +216,6 @@ message Request
         uint32 get_process_info = 5;
         string test_log=6;
         string get_tracepoint_info = 7;
+        bool get_hw_id_map = 8;
     }
 }

--- a/gputop-webui/ajax/metrics.html
+++ b/gputop-webui/ajax/metrics.html
@@ -3,6 +3,12 @@
         <div style="display: flex; flex-direction: row;">
             <div style="display: flex; flex-direction: column; flex: 0 1 75%; align-items: center;">
                 <div style="display: flex; flex-direction: row; flex: 0 1; align-items: center;">
+                    <div class="dropdown" id="ctx_mode-menu" style="padding-right: 5em;">
+                        <a class="dropdown-toggle" data-toggle="dropdown" id="ctx_mode-dropdown-anchor" href="#">Ctx_Mode<span class="caret"></span></a>
+                        <ul class="dropdown-menu" id="ctx_mode-menu-list">
+                          <li>Loading... <span class="glyphicon glyphicon-refresh spinning"></span></li>
+                        </ul>
+                    </div>
                     <div class="dropdown" id="metrics-menu" style="padding-right: 1em;">
                         <a class="dropdown-toggle" data-toggle="dropdown" id="metrics-dropdown-anchor" href="#">Metric Set<span class="caret"></span></a>
                         <ul class="dropdown-menu" id="metrics-menu-list">

--- a/gputop-webui/gputop-ui.js
+++ b/gputop-webui/gputop-ui.js
@@ -869,6 +869,45 @@ GputopUI.prototype.metric_not_supported = function(metric) {
     alert(" Metric not supported " + metric.title_)
 }
 
+GputopUI.prototype.get_vgpu_id = function(ctx_mode) {
+    var spstr;
+    if (ctx_mode === "Global")
+        return 0;
+    else {
+        spstr = ctx_mode.split("");
+        return (parseInt(spstr[spstr.length-1]));
+    }
+}
+
+GputopUI.prototype.update_vgpuID_hwID = function(hw_id) {
+    ctx_hw_id_ = [];
+    vgpu_id_ = [];
+    ctx_mode = ['Global'];
+    map_vgpuID_hwID = [0];
+
+    hw_id.ctx_hw_id.forEach((ctx_hw_id, i) => {
+         ctx_hw_id_.push(ctx_hw_id);
+    });
+    hw_id.vgpu_id.forEach((vgpu_id, i) => {
+         vgpu_id_.push(vgpu_id);
+    });
+
+    var map_length = Math.max.apply(Math, vgpu_id_);
+
+    for (var i = 0; i < map_length; i++ ) {
+         map_vgpuID_hwID[vgpu_id_[i]] = ctx_hw_id_[i];
+    }
+    for (var i = 1; i < vgpu_id_.length+1; i++) {
+         ctx_mode[i]='vGPU'+vgpu_id_[i-1];
+    }
+    ctx_mode.sort();
+
+    $("#ctx_mode-menu-list").empty();
+        for (var i = 0; i < ctx_mode.length; i++) {
+        $("#ctx_mode-menu-list").append('<li><a id="' + ctx_mode[i] + '" href="#">' + ctx_mode[i] + '</a></li>');
+        }
+}
+
 /* XXX: this is essentially the first entry point into GputopUI after
  * connecting to the server, after Gputop has been initialized */
 GputopUI.prototype.update_features = function(features) {
@@ -951,6 +990,13 @@ GputopUI.prototype.update_features = function(features) {
             }).call(this, this.metrics_[i]);
         }
         this.select_metric_set(this.metrics_[0]);
+
+        $("#ctx_mode-menu-list").empty();
+
+        $("#ctx_mode-dropdown-anchor").html('<h3>' + 'Global' + '<span class="caret"></span></h3>');
+        $('#ctx_mode-dropdown-anchor').click(() => {
+            this.request_hw_id_map();
+        });
 
         if (this.current_tab !== undefined &&
             this.current_tab.id === "overview-tab-anchor")


### PR DESCRIPTION
There are 4 commits in the pull-request. 
The first one is, same as #164, to fix counter filtering and graph plotting issues when one metric set is selected again. I think you can ignore or close that #164 request.
The last 3 commits are about per virtual GPU counter profiling, which are usage for graphics workloads running inside virtual machines. User can select a specific vGPU on the webui or through gputop-csv to observe each vGPU performance.