### PR TITLE
Support for per-vGPU mode profiling

### DIFF
--- a/gputop-client-c/gputop-client-c-bindings.cpp
+++ b/gputop-client-c/gputop-client-c-bindings.cpp
@@ -115,6 +115,8 @@ gputop_cc_handle_i915_perf_message_binding(const v8::FunctionCallbackInfo<Value>
     struct gputop_cc_stream *stream = (struct gputop_cc_stream *)ptr->ptr_;
 
     unsigned int len = args[2]->NumberValue();
+    unsigned int ctx_hw_id = args[5]->NumberValue();
+    unsigned int idle_flag = args[6]->NumberValue();
 
     if (!args[1]->IsArrayBufferView()) {
         isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Expected 2nd argument to be an ArrayBufferView")));
@@ -167,7 +169,9 @@ gputop_cc_handle_i915_perf_message_binding(const v8::FunctionCallbackInfo<Value>
                                        static_cast<uint8_t *>(data_contents.Data()) + offset,
                                        len,
                                        accumulators,
-                                       n_accumulators);
+                                       n_accumulators,
+                                       ctx_hw_id,
+                                       idle_flag);
 }
 
 void

--- a/gputop-client-c/gputop-client-c-runtime-bindings.cpp
+++ b/gputop-client-c/gputop-client-c-runtime-bindings.cpp
@@ -160,5 +160,15 @@ _gputop_cr_accumulator_end_update(void)
     fn->Call(gputop, ARRAY_LENGTH(argv), argv);
 }
 
+void
+_gputop_cr_send_idle_flag(int idle_flag)
+{
+    Isolate* isolate = Isolate::GetCurrent();
+    HandleScope scope(isolate);
 
+    Local<Object> gputop = Local<Object>::New(isolate, gputop_cc_singleton);
+    Local<Function> fn = Local<Function>::Cast(gputop->Get(String::NewFromUtf8(isolate, "send_idle_flag")));
 
+    Local<Value> argv[] = {Number::New(isolate, idle_flag)};
+    fn->Call(gputop, ARRAY_LENGTH(argv), argv);
+}

--- a/gputop-client-c/gputop-client-c-runtime.h
+++ b/gputop-client-c/gputop-client-c-runtime.h
@@ -66,6 +66,7 @@ bool _gputop_cr_accumulator_start_update(struct gputop_cc_stream *stream,
 void _gputop_cr_accumulator_append_count(int counter,
                                          double max, double value);
 void _gputop_cr_accumulator_end_update(void);
+void _gputop_cr_send_idle_flag(int idle_flag);
 
 #ifdef __cplusplus
 }

--- a/gputop-client-c/gputop-client-c.c
+++ b/gputop-client-c/gputop-client-c.c
@@ -96,6 +96,30 @@ gputop_cc_get_counter_id(const char *hw_config_guid, const char *counter_symbol_
 }
 
 static void
+reset_forward_oa_accumulator_events(struct gputop_cc_stream *stream,
+                              struct gputop_cc_oa_accumulator *oa_accumulator,
+                              uint32_t events)
+{
+    struct gputop_metric_set *oa_metric_set = stream->oa_metric_set;
+
+    if (!_gputop_cr_accumulator_start_update(stream,
+                                             oa_accumulator,
+                                             events,
+                                             oa_accumulator->first_timestamp,
+                                             oa_accumulator->last_timestamp))
+        return;
+
+    for (int i = 0; i < oa_metric_set->n_counters; i++) {
+
+        double d_value = 0;
+        uint64_t max = 0;
+        _gputop_cr_accumulator_append_count(i, max, d_value);
+    }
+
+    _gputop_cr_accumulator_end_update();
+}
+
+static void
 forward_oa_accumulator_events(struct gputop_cc_stream *stream,
                               struct gputop_cc_oa_accumulator *oa_accumulator,
                               uint32_t events)
@@ -204,14 +228,16 @@ void EMSCRIPTEN_KEEPALIVE
 gputop_cc_handle_i915_perf_message(struct gputop_cc_stream *stream,
                                    uint8_t *data, int data_len,
                                    struct gputop_cc_oa_accumulator **accumulators,
-                                   int n_accumulators)
+                                   int n_accumulators,
+                                   int ctx_hw_id,
+                                   int idle_flag)
 {
     const struct drm_i915_perf_record_header *header;
     uint8_t *last = NULL;
 
     assert(stream);
 
-    if (stream->continuation_report)
+    if (stream->continuation_report && (idle_flag < 4))
         last = stream->continuation_report;
     else {
         for (int i = 0; i < n_accumulators; i++) {
@@ -220,8 +246,13 @@ gputop_cc_handle_i915_perf_message(struct gputop_cc_stream *stream,
 
             assert(oa_accumulator);
             gputop_cc_oa_accumulator_clear(oa_accumulator);
+            reset_forward_oa_accumulator_events(stream, oa_accumulator, 1);
+            idle_flag = 4;
         }
     }
+
+    if (idle_flag < 4)
+        idle_flag++;
 
     //int i = 0;
     for (header = (void *)data;
@@ -250,34 +281,35 @@ gputop_cc_handle_i915_perf_message(struct gputop_cc_stream *stream,
         case DRM_I915_PERF_RECORD_SAMPLE: {
             struct oa_sample *sample = (struct oa_sample *)header;
 
-            if (last) {
-                for (int i = 0; i < n_accumulators; i++) {
-                    struct gputop_cc_oa_accumulator *oa_accumulator =
-                        accumulators[i];
+            if (sample->oa_report[8] == ctx_hw_id || ctx_hw_id == 0) {
+                idle_flag = 0;
 
-                    assert(oa_accumulator);
+                if (last) {
+                    for (int i = 0; i < n_accumulators; i++) {
+                        struct gputop_cc_oa_accumulator *oa_accumulator =
+                            accumulators[i];
 
-                    if (gputop_cc_oa_accumulate_reports(oa_accumulator,
+                        assert(oa_accumulator);
+
+                        if (gputop_cc_oa_accumulate_reports(oa_accumulator,
                                                         last, sample->oa_report))
-                    {
-                        uint64_t elapsed = (oa_accumulator->last_timestamp -
+                        {
+                            uint64_t elapsed = (oa_accumulator->last_timestamp -
                                             oa_accumulator->first_timestamp);
-                        uint32_t events = 0;
-                        //gputop_cr_console_log("i915_oa: accumulated reports\n");
+                            uint32_t events = 0;
+                            //gputop_cr_console_log("i915_oa: accumulated reports\n");
 
-                        if (elapsed > oa_accumulator->aggregation_period) {
-                            //gputop_cr_console_log("i915_oa: PERIOD ELAPSED (%d)\n", (int)oa_accumulator->aggregation_period);
-                            events |= ACCUMULATOR_EVENT_PERIOD_ELAPSED;
+                            if (elapsed > oa_accumulator->aggregation_period) {
+                                //gputop_cr_console_log("i915_oa: PERIOD ELAPSED (%d)\n", (int)oa_accumulator->aggregation_period);
+                                events |= ACCUMULATOR_EVENT_PERIOD_ELAPSED;
+                            }
+                            if (events)
+                                forward_oa_accumulator_events(stream, oa_accumulator, events);
                         }
-
-                        if (events)
-                            forward_oa_accumulator_events(stream, oa_accumulator, events);
                     }
                 }
-            }
-
             last = sample->oa_report;
-
+            }
             break;
         }
 
@@ -286,6 +318,8 @@ gputop_cc_handle_i915_perf_message(struct gputop_cc_stream *stream,
             return;
         }
     }
+
+    _gputop_cr_send_idle_flag(idle_flag);
 
     if (last) {
         int raw_size = stream->oa_metric_set->perf_raw_size;

--- a/gputop-client-c/gputop-client-c.h
+++ b/gputop-client-c/gputop-client-c.h
@@ -92,7 +92,9 @@ int gputop_cc_get_counter_id(const char *guid, const char *counter_symbol_name);
 void gputop_cc_handle_i915_perf_message(struct gputop_cc_stream *stream,
                                         uint8_t *data, int data_len,
                                         struct gputop_cc_oa_accumulator **accumulators,
-                                        int n_accumulators);
+                                        int n_accumulators,
+                                        int ctx_hw_id,
+                                        int idle_flag);
 
 void gputop_cc_reset_system_properties(void);
 void gputop_cc_set_system_property(const char *name, double value);

--- a/gputop-client-c/gputop-web-lib.js
+++ b/gputop-client-c/gputop-web-lib.js
@@ -93,6 +93,13 @@ var LibraryGpuTopWeb = {
         else
             console.error("Gputop singleton not initialized");
     },
+    _gputop_cr_send_idle_flag: function(idle_flag) {
+    var gputop = Module['gputop_singleton'];
+        if (gputop !== undefined)
+            gputop.send_idle_flag.call(gputop, idle_flag);
+        else
+            console.error("Gputop singleton not initialized");
+    },
 };
 
 autoAddDeps(LibraryGpuTopWeb, '$GPUTop');

--- a/gputop-client/gputop.js
+++ b/gputop-client/gputop.js
@@ -30,6 +30,11 @@
 var is_nodejs = false;
 var using_emscripten = true;
 
+var ctx_hw_id_ = [];
+var vgpu_id_ = [];
+var ctx_mode=['Global'];
+var map_vgpuID_hwID = [0];
+
 if (typeof module !== 'undefined' && module.exports) {
 
     var WebSocket = require('ws');
@@ -737,6 +742,7 @@ Gputop.prototype.set_demo_architecture = function(architecture) {
 
     this.demo_architecture = architecture;
     this.is_connected_ = true;
+    this.request_hw_id_map();
     this.request_features();
 }
 
@@ -1383,6 +1389,16 @@ Gputop.prototype.rpc_request = function(method, value, closure) {
     }
 }
 
+Gputop.prototype.request_hw_id_map = function() {
+    if (!this.is_demo()) {
+        if (this.socket_.readyState == is_nodejs ? 1 : WebSocket.OPEN) {
+            this.rpc_request('get_hw_id_map', true);
+        } else {
+            this.log("Can't request context hardware ID map while not connected", this.ERROR);
+        }
+    }
+}
+
 Gputop.prototype.request_features = function() {
     if (!this.is_demo()) {
         if (this.socket_.readyState == is_nodejs ? 1 : WebSocket.OPEN) {
@@ -1671,6 +1687,9 @@ function gputop_socket_on_message(evt) {
                 stream.dispatchEvent(ev);
             }
             break;
+        case 'hw_id':
+            this.update_vgpuID_hwID(msg.hw_id);
+            break;
         }
 
         if (msg.reply_uuid in this.rpc_closures_) {
@@ -1824,6 +1843,7 @@ Gputop.prototype.connect = function(address, onopen, onclose, onerror) {
                 this.log('Connecting to ' + websocket_url);
                 this.socket_ = this.connect_web_socket(websocket_url, () => { //onopen
                     this.is_connected_ = true;
+                    this.request_hw_id_map();
                     this.request_features();
 
                     var ev = { type: "open" };
@@ -1839,6 +1859,7 @@ Gputop.prototype.connect = function(address, onopen, onclose, onerror) {
                 });
             } else {
                 this.is_connected_ = true;
+                this.request_hw_id_map();
                 this.request_features();
 
                 var ev = { type: "open" };

--- a/gputop-client/gputop.js
+++ b/gputop-client/gputop.js
@@ -30,11 +30,6 @@
 var is_nodejs = false;
 var using_emscripten = true;
 
-var ctx_hw_id_ = [];
-var vgpu_id_ = [];
-var ctx_mode=['Global'];
-var map_vgpuID_hwID = [0];
-
 if (typeof module !== 'undefined' && module.exports) {
 
     var WebSocket = require('ws');
@@ -484,7 +479,7 @@ Gputop.prototype.clear_accumulated_metrics = function(metric) {
     }
 }
 
-Gputop.prototype.replay_i915_perf_history = function(metric) {
+Gputop.prototype.replay_i915_perf_history = function(metric, hw_id) {
     this.clear_accumulated_metrics(metric);
 
     var stream = metric.stream;
@@ -520,7 +515,9 @@ Gputop.prototype.replay_i915_perf_history = function(metric) {
                                                        stack_data,
                                                        data.length,
                                                        vec,
-                                                       n_accumulators);
+                                                       n_accumulators,
+                                                       hw_id,
+                                                       this.idle_flag);
         } else {
             var vec = [];
             for (var j = 0; j < n_accumulators; j++) {
@@ -532,7 +529,9 @@ Gputop.prototype.replay_i915_perf_history = function(metric) {
                                                    stack_data,
                                                    data.length,
                                                    vec,
-                                                   n_accumulators);
+                                                   n_accumulators,
+                                                   hw_id,
+                                                   this.idle_flag);
         }
 
         cc.Runtime.stackRestore(sp);
@@ -667,6 +666,10 @@ Gputop.prototype.accumulator_end_update = function () {
     this.notify_accumulator_events(metric,
                                    update.accumulator,
                                    update.events_mask);
+}
+
+Gputop.prototype.send_idle_flag = function (idle_flag) {
+    this.idle_flag = idle_flag;
 }
 
 Gputop.prototype.accumulator_clear = function (accumulator) {
@@ -1739,7 +1742,9 @@ function gputop_socket_on_message(evt) {
                                                            stack_data,
                                                            data.length,
                                                            vec,
-                                                           n_accumulators);
+                                                           n_accumulators,
+                                                           this.current_hw_id,
+                                                           this.idle_flag);
             } else {
                 var vec = [];
                 for (var i = 0; i < n_accumulators; i++) {
@@ -1751,7 +1756,9 @@ function gputop_socket_on_message(evt) {
                                                        stack_data,
                                                        data.length,
                                                        vec,
-                                                       n_accumulators);
+                                                       n_accumulators,
+                                                       this.current_hw_id,
+                                                       this.idle_flag);
             }
 
             cc.Runtime.stackRestore(sp);

--- a/gputop-data/gputop.proto
+++ b/gputop-data/gputop.proto
@@ -134,6 +134,11 @@ message TracepointInfo
     required string sample_format = 2;
 }
 
+message HW_ID
+{
+    repeated uint64 ctx_hw_id = 1;
+    repeated uint64 vgpu_id = 2;
+}
 
 message Message
 {
@@ -149,6 +154,7 @@ message Message
         ProcessInfo process_info = 8;
         CpuStatsSet cpu_stats = 9;
         TracepointInfo tracepoint_info = 10;
+        HW_ID hw_id = 11;
     }
 }
 
@@ -210,5 +216,6 @@ message Request
         uint32 get_process_info = 5;
         string test_log=6;
         string get_tracepoint_info = 7;
+        bool get_hw_id_map = 8;
     }
 }

--- a/gputop-server/gputop-server.c
+++ b/gputop-server/gputop-server.c
@@ -69,7 +69,6 @@ static uv_timer_t timer;
 static bool update_queued;
 static uv_idle_t update_idle;
 
-
 enum {
     WS_MESSAGE_PERF = 1,
     WS_MESSAGE_PROTOBUF,
@@ -974,6 +973,72 @@ gputop_get_cmd_line_pid(uint32_t pid, char *buf, int len)
 }
 
 static void
+handle_update_hw_id_map(uint64_t *vgpu_id,
+                        uint64_t *ctx_hw_id,
+                        int *current_vgpu_num)
+{
+    int i = 0;
+    int UUID_length = 36;
+    DIR *vgpu_dir;
+    char *vgpu_path="/sys/bus/pci/devices/0000:00:02.0";
+    char *vgpu_id_path, *hw_id_path;
+    struct dirent *entry;
+    bool success_vgpu_id, success_hw_id;
+
+    vgpu_dir=opendir(vgpu_path);
+    if (vgpu_dir == NULL) {
+        fprintf(stderr, "The path %s doesn't exist!\n", vgpu_path);
+        return;
+    }
+
+    while (entry = readdir(vgpu_dir)) {
+        if (entry->d_type == DT_DIR && (strlen(entry->d_name)==UUID_length)) {
+            int ret_vgpu_id_path = asprintf(&vgpu_id_path, "%s/%s/intel_vgpu/vgpu_id", vgpu_path, entry->d_name);
+            assert(ret_vgpu_id_path != -1);
+            int ret_hw_id_path = asprintf(&hw_id_path, "%s/%s/intel_vgpu/hw_id", vgpu_path, entry->d_name);
+            assert(hw_id_path != -1);
+            success_vgpu_id = gputop_read_file_uint64(vgpu_id_path, vgpu_id);
+            free(vgpu_id_path);
+            vgpu_id++;
+            success_hw_id = gputop_read_file_uint64(hw_id_path, ctx_hw_id);
+            free(hw_id_path);
+            ctx_hw_id++;
+            i++;
+        }
+    }
+
+    closedir(vgpu_dir);
+    *current_vgpu_num = i;
+}
+
+static void
+handle_get_hw_id_map(h2o_websocket_conn_t *conn,
+                     Gputop__Request *request)
+{
+    int i = 0, max_vgpu_num = 7;
+    int current_vgpu_num = 0;
+    uint64_t ctx_hw_id[max_vgpu_num];
+    uint64_t vgpu_id[max_vgpu_num];
+
+    handle_update_hw_id_map(vgpu_id, ctx_hw_id, &current_vgpu_num);
+
+    Gputop__Message message = GPUTOP__MESSAGE__INIT;
+    Gputop__HWID hw_id = GPUTOP__HW__ID__INIT;
+
+    message.reply_uuid = request->uuid;
+    message.cmd_case = GPUTOP__MESSAGE__CMD_HW_ID;
+
+    hw_id.n_ctx_hw_id = current_vgpu_num;
+    hw_id.ctx_hw_id = ctx_hw_id;
+
+    hw_id.n_vgpu_id = current_vgpu_num;
+    hw_id.vgpu_id = vgpu_id;
+
+    message.hw_id = &hw_id;
+    send_pb_message(conn, &message.base);
+}
+
+static void
 handle_get_process_info(h2o_websocket_conn_t *conn,
                     Gputop__Request *request)
 {
@@ -1329,6 +1394,10 @@ static void on_ws_message(h2o_websocket_conn_t *conn,
             break;
         case GPUTOP__REQUEST__REQ_TEST_LOG:
             fprintf(stderr, "TEST LOG: %s\n", request->test_log);
+            break;
+        case GPUTOP__REQUEST__REQ_GET_HW_ID_MAP:
+            fprintf(stderr, "Get HW_ID_MAP request received\n");
+            handle_get_hw_id_map(conn, request);
             break;
         case GPUTOP__REQUEST__REQ__NOT_SET:
             assert(0);

--- a/gputop-webui/ajax/metrics.html
+++ b/gputop-webui/ajax/metrics.html
@@ -3,6 +3,12 @@
         <div style="display: flex; flex-direction: row;">
             <div style="display: flex; flex-direction: column; flex: 0 1 75%; align-items: center;">
                 <div style="display: flex; flex-direction: row; flex: 0 1; align-items: center;">
+                    <div class="dropdown" id="ctx_mode-menu" style="padding-right: 5em;">
+                        <a class="dropdown-toggle" data-toggle="dropdown" id="ctx_mode-dropdown-anchor" href="#">Ctx_Mode<span class="caret"></span></a>
+                        <ul class="dropdown-menu" id="ctx_mode-menu-list">
+                          <li>Loading... <span class="glyphicon glyphicon-refresh spinning"></span></li>
+                        </ul>
+                    </div>
                     <div class="dropdown" id="metrics-menu" style="padding-right: 1em;">
                         <a class="dropdown-toggle" data-toggle="dropdown" id="metrics-dropdown-anchor" href="#">Metric Set<span class="caret"></span></a>
                         <ul class="dropdown-menu" id="metrics-menu-list">

--- a/gputop-webui/gputop-ui.js
+++ b/gputop-webui/gputop-ui.js
@@ -869,6 +869,45 @@ GputopUI.prototype.metric_not_supported = function(metric) {
     alert(" Metric not supported " + metric.title_)
 }
 
+GputopUI.prototype.get_vgpu_id = function(ctx_mode) {
+    var spstr;
+    if (ctx_mode === "Global")
+        return 0;
+    else {
+        spstr = ctx_mode.split("");
+        return (parseInt(spstr[spstr.length-1]));
+    }
+}
+
+GputopUI.prototype.update_vgpuID_hwID = function(hw_id) {
+    ctx_hw_id_ = [];
+    vgpu_id_ = [];
+    ctx_mode = ['Global'];
+    map_vgpuID_hwID = [0];
+
+    hw_id.ctx_hw_id.forEach((ctx_hw_id, i) => {
+         ctx_hw_id_.push(ctx_hw_id);
+    });
+    hw_id.vgpu_id.forEach((vgpu_id, i) => {
+         vgpu_id_.push(vgpu_id);
+    });
+
+    var map_length = Math.max.apply(Math, vgpu_id_);
+
+    for (var i = 0; i < map_length; i++ ) {
+         map_vgpuID_hwID[vgpu_id_[i]] = ctx_hw_id_[i];
+    }
+    for (var i = 1; i < vgpu_id_.length+1; i++) {
+         ctx_mode[i]='vGPU'+vgpu_id_[i-1];
+    }
+    ctx_mode.sort();
+
+    $("#ctx_mode-menu-list").empty();
+        for (var i = 0; i < ctx_mode.length; i++) {
+        $("#ctx_mode-menu-list").append('<li><a id="' + ctx_mode[i] + '" href="#">' + ctx_mode[i] + '</a></li>');
+        }
+}
+
 /* XXX: this is essentially the first entry point into GputopUI after
  * connecting to the server, after Gputop has been initialized */
 GputopUI.prototype.update_features = function(features) {
@@ -951,6 +990,13 @@ GputopUI.prototype.update_features = function(features) {
             }).call(this, this.metrics_[i]);
         }
         this.select_metric_set(this.metrics_[0]);
+
+        $("#ctx_mode-menu-list").empty();
+
+        $("#ctx_mode-dropdown-anchor").html('<h3>' + 'Global' + '<span class="caret"></span></h3>');
+        $('#ctx_mode-dropdown-anchor').click(() => {
+            this.request_hw_id_map();
+        });
 
         if (this.current_tab !== undefined &&
             this.current_tab.id === "overview-tab-anchor")

--- a/gputop-webui/gputop-ui.js
+++ b/gputop-webui/gputop-ui.js
@@ -170,6 +170,9 @@ function GputopUI () {
 
     this.paused = false;
     this.current_metric_set = undefined;
+    this.current_hw_id = 0;
+
+    this.idle_flag = 0;
 
     this.selected_counter = undefined;
 
@@ -280,24 +283,25 @@ GputopUI.prototype.filter_counters = function() {
     });
 }
 
-GputopUI.prototype.select_metric_set = function(metric) {
-    if (this.current_metric_set === metric)
+GputopUI.prototype.select_metric_set = function(metric, hw_id) {
+    if (this.current_metric_set === metric &&  this.current_hw_id === hw_id)
         return;
 
     $("#metrics-dropdown-anchor").html('<h3>' + metric.name + '<span class="caret"></span></h3>');
 
-    $('#counter_list').empty();
-    for (var i = 0; i < metric.cc_counters.length; i++) {
-        var counter = metric.cc_counters[i];
-        var counter_row_id = "row_" + metric.underscore_name + '_' + counter.underscore_name;
-        counter.record_data = false;
-        counter.zero = true;
-        var select_marker_id = counter_row_id + "_marker";
-        var bar_id = counter_row_id + "_bar";
-        var txt_value_id = counter_row_id + "_value";
-        var stats_toggle_id = counter_row_id + "_toggle";
+    if (this.current_metric_set === undefined || this.current_metric_set !== metric) {
+        $('#counter_list').empty();
+        for (var i = 0; i < metric.cc_counters.length; i++) {
+            var counter = metric.cc_counters[i];
+            var select_marker_id = counter_row_id + "_marker";
+            counter.record_data = false;
+            counter.zero = true;
+            var counter_row_id = "row_" + metric.underscore_name + '_' + counter.underscore_name;
+            var bar_id = counter_row_id + "_bar";
+            var txt_value_id = counter_row_id + "_value";
+            var stats_toggle_id = counter_row_id + "_toggle";
 
-        var row_template = `
+            var row_template = `
 <div class="metric_row" id="${counter_row_id}" data-toggle="tooltip" title="${counter.description}">
     <div class="counter-select-mark" id="${select_marker_id}" style="visibility: hidden;">❭</div>
     <div class="counter_name">${counter.name}</div>
@@ -308,51 +312,50 @@ GputopUI.prototype.select_metric_set = function(metric) {
     <div class="progress_text" id="${txt_value_id}"></div>
 </div>`;
 
-        $('#counter_list').append(row_template);
+            $('#counter_list').append(row_template);
 
-        counter.row_div_ = $('#' + counter_row_id);
-        counter.row_marker_div_ = $('#' + select_marker_id);
-        counter.bar_div_ = $('#' + bar_id);
-        counter.txt_value_div_ = $('#' + txt_value_id);
-        counter.row_div_.data("counter", counter);
-        counter.stats_toggle_div_ = $('#' +  stats_toggle_id);
-        counter.stats_toggle_div_.data("counter", counter);
+            counter.row_div_ = $('#' + counter_row_id);
+            counter.row_marker_div_ = $('#' + select_marker_id);
+            counter.bar_div_ = $('#' + bar_id);
+            counter.txt_value_div_ = $('#' + txt_value_id);
+            counter.row_div_.data("counter", counter);
+            counter.stats_toggle_div_ = $('#' +  stats_toggle_id);
+            counter.stats_toggle_div_.data("counter", counter);
+        }
+
+        $('.counter-stats-button').bootstrapToggle();
+        $('.counter-stats-button').css({
+        "height": "100%",
+        });
+        $('.counter-stats-button').change((ev) => {
+        var counter = $(ev.target).data("counter");
+            counter.record_data = !$(ev.target).prop('checked');
+
+            for (var i = 0; i < this.plotly_graphs.length; i++) {
+                var graph = this.plotly_graphs[i];
+                if (graph.counter === counter) {
+                    if (graph.plotly_div !== undefined) {
+                        graph.plotly_div.remove();
+                        graph.plotly_div = undefined;
+                    }
+                    graph.counter.graph = undefined;
+                    this.plotly_graphs.splice(i, 1);
+                    break;
+                }
+            }
+        });
+
+        $('.metric_row').click((ev) => {
+            var counter = $(ev.delegateTarget).data("counter");
+            this.select_counter(counter);
+        });
+        $('.equation').click((ev) => {
+            var counter = $(ev.target).data("counter");
+            this.select_counter(counter);
+        });
     }
 
-    $('.counter-stats-button').bootstrapToggle();
-    $('.counter-stats-button').css({
-        "height": "100%",
-    });
-    $('.counter-stats-button').change((ev) => {
-        var counter = $(ev.target).data("counter");
-        counter.record_data = !$(ev.target).prop('checked');
-
-        for (var i = 0; i < this.plotly_graphs.length; i++) {
-            var graph = this.plotly_graphs[i];
-            if (graph.counter === counter) {
-                if (graph.plotly_div !== undefined) {
-                    graph.plotly_div.remove();
-                    graph.plotly_div = undefined;
-                }
-                graph.counter.graph = undefined;
-                this.plotly_graphs.splice(i, 1);
-                break;
-            }
-        }
-    });
-
-    $('.metric_row').click((ev) => {
-        var counter = $(ev.delegateTarget).data("counter");
-        this.select_counter(counter);
-    });
-    $('.equation').click((ev) => {
-        var counter = $(ev.target).data("counter");
-        this.select_counter(counter);
-    });
-
-    this.filter_counters();
-
-    this.update_metric_set_stream(metric);
+    this.update_metric_set_stream(metric, hw_id);
 }
 
 /* Returns: the duration that a single graph pixel corresponds to
@@ -392,7 +395,7 @@ GputopUI.prototype.calculate_sample_state_for_zoom = function () {
 /* Handles opening or re-opening a metric set stream, but is
  * also careful to avoid some redundant re-opens.
  */
-GputopUI.prototype.update_metric_set_stream = function(metric) {
+GputopUI.prototype.update_metric_set_stream = function(metric, hw_id) {
     var sampling_state = this.calculate_sample_state_for_zoom();
     var config = {
         oa_exponent: sampling_state.oa_exponent,
@@ -434,7 +437,7 @@ GputopUI.prototype.update_metric_set_stream = function(metric) {
                 metric.bars_accumulator = metric.create_oa_accumulator({ period_ns: 500000000 });
 
                 if (metric.open_config.paused)
-                    this.replay_i915_perf_history(metric);
+                    this.replay_i915_perf_history(metric, hw_id);
 
                 this.queue_redraw();
             },
@@ -443,7 +446,8 @@ GputopUI.prototype.update_metric_set_stream = function(metric) {
     }
 
     if (this.current_metric_set !== undefined &&
-        this.current_metric_set.open_config !== undefined)
+        this.current_metric_set.open_config !== undefined &&
+        this.current_hw_id !== undefined)
     {
         var current_metric = this.current_metric_set;
         var current_config = this.current_metric_set.open_config;
@@ -463,9 +467,11 @@ GputopUI.prototype.update_metric_set_stream = function(metric) {
 
         if (current_metric !== metric ||
             current_config.paused !== config.paused ||
-            current_config.oa_exponent !== config.oa_exponent)
+            current_config.oa_exponent !== config.oa_exponent ||
+            this.current_hw_id !== hw_id)
         {
             this.current_metric_set = metric;
+            this.current_hw_id = hw_id;
 
             current_metric.close((ev) => {
                 _do_open.call(this);
@@ -475,7 +481,7 @@ GputopUI.prototype.update_metric_set_stream = function(metric) {
              * update the graph accumulator in case the zoom level has changed.
              */
             metric.set_oa_accumulator_period(metric.graph_accumulator,
-                                             accumulator_period);
+                                             accumulation_period);
         }
     } else {
         this.current_metric_set = metric;
@@ -493,7 +499,11 @@ GputopUI.prototype.set_zoom = function(zoom) {
     if (metric === undefined)
         return;
 
-    this.update_metric_set_stream(metric);
+    var hw_id = this.current_hw_id;
+    if (hw_id === undefined)
+        return;
+
+    this.update_metric_set_stream(metric, hw_id);
 }
 
 GputopUI.prototype.set_paused = function(paused) {
@@ -506,7 +516,11 @@ GputopUI.prototype.set_paused = function(paused) {
     if (metric === undefined)
         return;
 
-    this.update_metric_set_stream(metric);
+    var hw_id = this.current_hw_id;
+    if (hw_id === undefined)
+        return;
+
+    this.update_metric_set_stream(metric, hw_id);
 }
 
 GputopUI.prototype.update_gpu_metrics_graph = function (timestamp) {
@@ -880,10 +894,10 @@ GputopUI.prototype.get_vgpu_id = function(ctx_mode) {
 }
 
 GputopUI.prototype.update_vgpuID_hwID = function(hw_id) {
-    ctx_hw_id_ = [];
-    vgpu_id_ = [];
-    ctx_mode = ['Global'];
-    map_vgpuID_hwID = [0];
+    var ctx_hw_id_ = [];
+    var vgpu_id_ = [];
+    var ctx_mode = ['Global'];
+    var map_vgpuID_hwID = [0];
 
     hw_id.ctx_hw_id.forEach((ctx_hw_id, i) => {
          ctx_hw_id_.push(ctx_hw_id);
@@ -903,9 +917,18 @@ GputopUI.prototype.update_vgpuID_hwID = function(hw_id) {
     ctx_mode.sort();
 
     $("#ctx_mode-menu-list").empty();
-        for (var i = 0; i < ctx_mode.length; i++) {
-        $("#ctx_mode-menu-list").append('<li><a id="' + ctx_mode[i] + '" href="#">' + ctx_mode[i] + '</a></li>');
-        }
+    for (var i = 0; i < ctx_mode.length; i++) {
+        (function(ctx_mode) {
+            $("#ctx_mode-menu-list").append('<li><a id="' + ctx_mode  + '" href="#">' + ctx_mode + '</a></li>');
+            $("#" + ctx_mode).click(() => {
+                $("#ctx_mode-dropdown-anchor").html('<h3>'  + ctx_mode  +  '<span class="caret"></span></h3>');
+                var select_vgpu_id = this.get_vgpu_id(ctx_mode);
+                var select_hw_id = map_vgpuID_hwID[select_vgpu_id];
+                this.select_metric_set(this.current_metric_set, select_hw_id);
+            });
+         }).call(this, ctx_mode[i]);
+
+    }
 }
 
 /* XXX: this is essentially the first entry point into GputopUI after
@@ -985,11 +1008,11 @@ GputopUI.prototype.update_features = function(features) {
                 $("#" + metric.uuid).click(() => {
                     //$('#metrics-menu').addClass("active");
                     $('#metrics-tab-anchor').tab('show');
-                    this.select_metric_set(metric);
+                    this.select_metric_set(metric, this.current_hw_id);
                 });
             }).call(this, this.metrics_[i]);
         }
-        this.select_metric_set(this.metrics_[0]);
+        this.select_metric_set(this.metrics_[0], this.current_hw_id);
 
         $("#ctx_mode-menu-list").empty();
 


### PR DESCRIPTION
These 3 commits are about per virtual GPU counter profiling, which are usage for graphics workloads running inside virtual machines. User can select a specific vGPU on the web ui or through gputop-csv to observe each vGPU performance.

Let me briefly introduce my idea. If we create 2 vGPUs, there are 3 states. ctx_mode = ["Global", "vGPU1", "vGPU2"], and corresponding hw_id = ["0", hw_id1, hw_id2]. The "Global" state means the current state, without applying my patch, that is, it shows the whole counter values for any context id. All of the vgpu_id and hw_id starts from non-zero value. Hence I define the hw_id as 0 to map the "Global" state. So in the beginning without selecting any hw id, the current_hw_id is 0, it works in the "Global" state.