### PR TITLE
meson: rework UI selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,16 @@ Without UI :
 meson . build
 ```
 
-With GLFW UI :
+With GLFW native UI for X11 and Wayland :
 
 ```
-meson . build -Dnative_ui=true
+meson . build -Dui=x11,wayland
 ```
 
 With Gtk+ UI :
 
 ```
-meson . build -Dnative_ui_gtk=true
+meson . build -Dui=gtk
 ```
 
 ## Building GPU Top
@@ -159,7 +159,7 @@ build the UI, you'll need to build the server in the different build
 directory).
 
 ```
-meson . build-webui -Dwebui=true --cross=scripts/meson-cross/emscripten-docker-debug.txt
+meson . build-webui -Dui=web --cross=scripts/meson-cross/emscripten-docker-debug.txt
 ```
 
 Create a directory to serve the UI and copy the files needed :

--- a/meson.build
+++ b/meson.build
@@ -19,9 +19,8 @@ cc = meson.get_compiler('cpp')
 
 prog_python2 = find_program('python2')
 
-build_native_ui = get_option('native_ui')
-build_webui = get_option('webui')
-if build_webui and build_native_ui
+build_ui = get_option('ui')
+if build_ui.contains('web') and (build_ui.contains('x11') or build_ui.contains('wayland'))
   error('Cannot build webui and native tools in the same build')
 endif
 
@@ -36,7 +35,7 @@ endif
 
 subdir('mesa')
 subdir('lib')
-if not build_webui
+if not build_ui.contains('web')
   libuv_dep = subproject('libuv').get_variable('libuv_dep')
   wslay_dep = subproject('wslay').get_variable('wslay_dep')
   h2o_dep = subproject('h2o').get_variable('h2o_dep')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,5 @@
-option('webui', type : 'boolean', value : 'false')
-option('native_ui', type : 'boolean', value : 'false')
-option('native_ui_gtk', type : 'boolean', value : 'false')
+option('ui',
+  type: 'array',
+  value: [],
+  choices: ['x11', 'wayland', 'gtk', 'web']
+)

--- a/ui/meson.build
+++ b/ui/meson.build
@@ -25,7 +25,7 @@ imgui = static_library('imgui', imgui_src,
                                    '-Wno-sign-compare'],
                        dependencies : imgui_deps)
 
-if build_webui
+if build_ui.contains('web')
   ui_src += [
     'imgui/imgui_impl_sdl_gles2.cpp',
     'gputop-emscripten-network.c',
@@ -38,7 +38,7 @@ if build_webui
              dependencies : gputop_client_dep,
 	     install : true)
 else
-  if build_native_ui
+  if build_ui.contains('x11') or build_ui.contains('wayland')
     glfw_ui_src = ui_src + [ 'imgui/imgui_impl_glfw_gl3.cpp',
                              'gputop-uv-network.c', ]
     glfw_ui_flags = ui_flags + [ '-DGPUTOP_UI_GLFW',
@@ -48,14 +48,15 @@ else
                      libuv_dep, wslay_dep,
                      dependency('threads'), ]
 
-    x11_dep = dependency('x11', required : false)
-    if x11_dep.found()
-      glfw_ui_flags += [ '-DGLFW_EXPOSE_NATIVE_X11', ]
+    if build_ui.contains('x11')
+      x11_dep = dependency('x11')
+      glfw_ui_flags += '-DGLFW_EXPOSE_NATIVE_X11'
       glfw_ui_deps += x11_dep
     endif
-    wayland_dep = dependency('wayland-client', required : false)
-    if wayland_dep.found()
-      glfw_ui_flags += [ '-DGLFW_EXPOSE_NATIVE_WAYLAND', ]
+
+    if build_ui.contains('wayland')
+      wayland_dep = dependency('wayland-client')
+      glfw_ui_flags += '-DGLFW_EXPOSE_NATIVE_WAYLAND'
       glfw_ui_deps += wayland_dep
     endif
 
@@ -67,7 +68,7 @@ else
 	       install : true)
   endif
 
-  if get_option('native_ui_gtk')
+  if build_ui.contains('gtk')
     gtk_dep = dependency('gtk+-3.0', version : '>= 3.18.0')
     cogl_dep = dependency('cogl-2.0-experimental')
     libsoup_dep = dependency('libsoup-2.4', version : '>= 2.60.3')


### PR DESCRIPTION
On my distro (Arch), GLFW only supports one platform at a time, so you can either have X11 or Wayland.

Meson previously detected the presence of x11 to decide whether to build the x11 UI, which wouldn't compile on my system running wayland with the wayland GLFW, even though libX11 was installed.

A better way of handling this is to let the user decide which platform to build, which this commit does. The option is an array, which means multiple UIs can be selected at the same time, and the build's success will depend on what the user's system allows.

*Note: I just realised I need to fix the travis config as well; I'll wait for an ack from you guys on the idea before I do that.*