### PR TITLE
scripts: do not use the extern keyword in kernel function declarations

### DIFF
--- a/scripts/i915-perf-kernelgen.py
+++ b/scripts/i915-perf-kernelgen.py
@@ -264,7 +264,7 @@ def output_sysfs_code(sets):
         c("}")
 
 
-    h("extern void i915_perf_load_test_config_" + chipset.lower() + "(struct drm_i915_private *dev_priv);")
+    h("void i915_perf_load_test_config_" + chipset.lower() + "(struct drm_i915_private *dev_priv);")
     h("\n")
 
     c("\n")


### PR DESCRIPTION
Using the extern keyword for function declarations is to be avoided in
the kernel.